### PR TITLE
[FEAT] 일기 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/smeme/server/controller/DiaryController.java
+++ b/src/main/java/com/smeme/server/controller/DiaryController.java
@@ -8,6 +8,8 @@ import java.net.URI;
 import java.security.Principal;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.smeme.server.dto.diary.DiaryRequestDTO;
+import com.smeme.server.dto.diary.DiaryResponseDTO;
 import com.smeme.server.service.DiaryService;
 import com.smeme.server.util.ApiResponse;
 
@@ -34,6 +37,12 @@ public class DiaryController {
 		return ResponseEntity
 			.created(getURI(diaryId))
 			.body(ApiResponse.success(SUCCESS_CREATE_DIARY.getMessage()));
+	}
+
+	@GetMapping("/{diaryId}")
+	public ResponseEntity<ApiResponse> getDiaryDetail(@PathVariable Long diaryId) {
+		DiaryResponseDTO response = diaryService.getDiaryDetail(diaryId);
+		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_DIARY.getMessage(), response));
 	}
 
 	private Long getMemberId(Principal principal) {

--- a/src/main/java/com/smeme/server/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/diary/DiaryResponseDTO.java
@@ -1,0 +1,57 @@
+package com.smeme.server.dto.diary;
+
+import static java.util.Objects.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import com.smeme.server.model.Correction;
+import com.smeme.server.model.Diary;
+import com.smeme.server.model.topic.Topic;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record DiaryResponseDTO(
+	Long diaryId,
+	String topic,
+	String content,
+	String createdAt,
+	String username,
+	List<CorrectionDTO> corrections
+) {
+	public static DiaryResponseDTO of(Diary diary) {
+		return DiaryResponseDTO.builder()
+			.diaryId(diary.getId())
+			.topic(getTopic(diary.getTopic()))
+			.content(diary.getContent())
+			.createdAt(getCreatedAt(diary.getCreatedAt()))
+			.username(diary.getMember().getUsername())
+			.corrections(getCorrections(diary.getCorrections()))
+			.build();
+	}
+
+	private static String getTopic(Topic topic) {
+		return nonNull(topic) ? topic.getContent() : "";
+	}
+
+	private static String getCreatedAt(LocalDateTime createdAt) {
+		return createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+	}
+
+	private static List<CorrectionDTO> getCorrections(List<Correction> corrections) {
+		return corrections.stream().map(CorrectionDTO::of).toList();
+	}
+}
+
+record CorrectionDTO(
+	Long correctionId,
+	String before,
+	String after
+) {
+	static CorrectionDTO of(Correction correction) {
+		return new CorrectionDTO(correction.getId(), correction.getBeforeSentence(), correction.getAfterSentence());
+	}
+}

--- a/src/main/java/com/smeme/server/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/diary/DiaryResponseDTO.java
@@ -22,14 +22,14 @@ public record DiaryResponseDTO(
 	String username,
 	List<CorrectionDTO> corrections
 ) {
-	public static DiaryResponseDTO of(Diary diary) {
+	public static DiaryResponseDTO of(Diary diary, List<Correction> corrections) {
 		return DiaryResponseDTO.builder()
 			.diaryId(diary.getId())
 			.topic(getTopic(diary.getTopic()))
 			.content(diary.getContent())
 			.createdAt(getCreatedAt(diary.getCreatedAt()))
 			.username(diary.getMember().getUsername())
-			.corrections(getCorrections(diary.getCorrections()))
+			.corrections(getCorrections(corrections))
 			.build();
 	}
 

--- a/src/main/java/com/smeme/server/repository/CorrectionRepository.java
+++ b/src/main/java/com/smeme/server/repository/CorrectionRepository.java
@@ -1,0 +1,12 @@
+package com.smeme.server.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.smeme.server.model.Correction;
+import com.smeme.server.model.Diary;
+
+public interface CorrectionRepository extends JpaRepository<Correction, Long> {
+	List<Correction> findByDiaryOrderByIdDesc(Diary diary);
+}

--- a/src/main/java/com/smeme/server/service/DiaryService.java
+++ b/src/main/java/com/smeme/server/service/DiaryService.java
@@ -1,10 +1,12 @@
 package com.smeme.server.service;
 
 import static com.smeme.server.util.message.ErrorMessage.*;
+import static java.util.Objects.*;
 
 import org.springframework.stereotype.Service;
 
 import com.smeme.server.dto.diary.DiaryRequestDTO;
+import com.smeme.server.dto.diary.DiaryResponseDTO;
 import com.smeme.server.model.Diary;
 import com.smeme.server.model.Member;
 import com.smeme.server.model.topic.Topic;
@@ -33,14 +35,26 @@ public class DiaryService {
 		return diary.getId();
 	}
 
+	public DiaryResponseDTO getDiaryDetail(Long diaryId) {
+		Diary diary = getDiary(diaryId);
+		return DiaryResponseDTO.of(diary);
+	}
+
+	private Diary getDiary(Long diaryId) {
+		return diaryRepository.findById(diaryId)
+			.orElseThrow(() -> new EntityNotFoundException(INVALID_DIARY.getMessage()));
+	}
+
 	private Member getMember(Long memberId) {
 		return memberRepository.findById(memberId)
 			.orElseThrow(() -> new EntityNotFoundException(INVALID_MEMBER.getMessage()));
 	}
 
 	private Topic getTopic(Long topicId) {
-		return topicRepository.findById(topicId)
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_TOPIC.getMessage()));
+		return nonNull(topicId)
+			? topicRepository.findById(topicId)
+			.orElseThrow(() -> new EntityNotFoundException(INVALID_TOPIC.getMessage()))
+			: null;
 	}
 
 	private boolean existTodayDiary(Member member) {

--- a/src/main/java/com/smeme/server/service/DiaryService.java
+++ b/src/main/java/com/smeme/server/service/DiaryService.java
@@ -3,13 +3,17 @@ package com.smeme.server.service;
 import static com.smeme.server.util.message.ErrorMessage.*;
 import static java.util.Objects.*;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.smeme.server.dto.diary.DiaryRequestDTO;
 import com.smeme.server.dto.diary.DiaryResponseDTO;
+import com.smeme.server.model.Correction;
 import com.smeme.server.model.Diary;
 import com.smeme.server.model.Member;
 import com.smeme.server.model.topic.Topic;
+import com.smeme.server.repository.CorrectionRepository;
 import com.smeme.server.repository.diary.DiaryRepository;
 import com.smeme.server.repository.MemberRepository;
 import com.smeme.server.repository.TopicRepository;
@@ -24,6 +28,7 @@ public class DiaryService {
 	private final DiaryRepository diaryRepository;
 	private final TopicRepository topicRepository;
 	private final MemberRepository memberRepository;
+	private final CorrectionRepository correctionRepository;
 
 	public Long createDiary(Long memberId, DiaryRequestDTO requestDTO) {
 		Member member = getMember(memberId);
@@ -37,7 +42,8 @@ public class DiaryService {
 
 	public DiaryResponseDTO getDiaryDetail(Long diaryId) {
 		Diary diary = getDiary(diaryId);
-		return DiaryResponseDTO.of(diary);
+		List<Correction> corrections = correctionRepository.findByDiaryOrderByIdDesc(diary);
+		return DiaryResponseDTO.of(diary, corrections);
 	}
 
 	private Diary getDiary(Long diaryId) {

--- a/src/main/java/com/smeme/server/util/message/ErrorMessage.java
+++ b/src/main/java/com/smeme/server/util/message/ErrorMessage.java
@@ -14,6 +14,7 @@ public enum ErrorMessage {
 
 	// diary
 	EXIST_TODAY_DIARY("일기는 하루에 한 번씩 작성할 수 있습니다."),
+	INVALID_DIARY("유효하지 않은 일기입니다."),
 
 	// topic
 	INVALID_TOPIC("유효하지 않은 랜덤주제입니다.")

--- a/src/main/java/com/smeme/server/util/message/ResponseMessage.java
+++ b/src/main/java/com/smeme/server/util/message/ResponseMessage.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ResponseMessage {
 	// diary
 	SUCCESS_CREATE_DIARY("일기 생성 성공"),
+	SUCCESS_GET_DIARY("일기 상세 조회 성공"),
 
 	// message
 	SUCCESS_PUSH_MESSAGE("푸시알람 요청 성공");


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #51 

## Work Description 💚
- 일기 상세 조회 기능을 구현했습니다.
- 클서 회의에서 결정한 내용대로 해당 기능에 **첨삭 리스트 데이터**를 추가했으며, 최신순 정렬로 id 역순 정렬로 설정했습니다.
- 랜덤주제(topic)이 null인 diary의 topic는 빈 값("") 처리했습니다.