### PR TITLE
[FEAT] 일기 수정 기능 구현

### DIFF
--- a/src/main/java/com/smeme/server/config/TimezoneConfig.java
+++ b/src/main/java/com/smeme/server/config/TimezoneConfig.java
@@ -1,0 +1,16 @@
+package com.smeme.server.config;
+
+import java.util.TimeZone;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimezoneConfig {
+
+	@PostConstruct
+	public void init() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
+}

--- a/src/main/java/com/smeme/server/controller/DiaryController.java
+++ b/src/main/java/com/smeme/server/controller/DiaryController.java
@@ -9,6 +9,7 @@ import java.security.Principal;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,6 +44,13 @@ public class DiaryController {
 	public ResponseEntity<ApiResponse> getDiaryDetail(@PathVariable Long diaryId) {
 		DiaryResponseDTO response = diaryService.getDiaryDetail(diaryId);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_DIARY.getMessage(), response));
+	}
+
+	@PatchMapping("/{diaryId}")
+	public ResponseEntity<ApiResponse> updateDiary(
+		@PathVariable Long diaryId, @RequestBody DiaryRequestDTO requestDTO) {
+		diaryService.updateDiary(diaryId, requestDTO);
+		return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_DAIRY.getMessage()));
 	}
 
 	private Long getMemberId(Principal principal) {

--- a/src/main/java/com/smeme/server/model/Diary.java
+++ b/src/main/java/com/smeme/server/model/Diary.java
@@ -69,7 +69,7 @@ public class Diary {
 
     public void updateContent(String content) {
         this.content = content;
-        this.updatedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.updatedAt = LocalDateTime.now();
     }
 
     private void setMember(Member member) {

--- a/src/main/java/com/smeme/server/model/Diary.java
+++ b/src/main/java/com/smeme/server/model/Diary.java
@@ -67,6 +67,11 @@ public class Diary {
         this.createdAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
     }
 
+    public void updateContent(String content) {
+        this.content = content;
+        this.updatedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+    }
+
     private void setMember(Member member) {
         if (Objects.nonNull(this.member)) {
             this.member.getDiaries().remove(this);

--- a/src/main/java/com/smeme/server/service/DiaryService.java
+++ b/src/main/java/com/smeme/server/service/DiaryService.java
@@ -4,6 +4,7 @@ import static com.smeme.server.util.message.ErrorMessage.*;
 import static java.util.Objects.*;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.smeme.server.dto.diary.DiaryRequestDTO;
 import com.smeme.server.dto.diary.DiaryResponseDTO;
@@ -19,12 +20,14 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DiaryService {
 
 	private final DiaryRepository diaryRepository;
 	private final TopicRepository topicRepository;
 	private final MemberRepository memberRepository;
 
+	@Transactional
 	public Long createDiary(Long memberId, DiaryRequestDTO requestDTO) {
 		Member member = getMember(memberId);
 		Topic topic = getTopic(requestDTO.topicId());
@@ -38,6 +41,12 @@ public class DiaryService {
 	public DiaryResponseDTO getDiaryDetail(Long diaryId) {
 		Diary diary = getDiary(diaryId);
 		return DiaryResponseDTO.of(diary);
+	}
+
+	@Transactional
+	public void updateDiary(Long diaryId, DiaryRequestDTO requestDTO) {
+		Diary diary = getDiary(diaryId);
+		diary.updateContent(requestDTO.content());
 	}
 
 	private Diary getDiary(Long diaryId) {

--- a/src/main/java/com/smeme/server/util/message/ResponseMessage.java
+++ b/src/main/java/com/smeme/server/util/message/ResponseMessage.java
@@ -9,6 +9,7 @@ public enum ResponseMessage {
 	// diary
 	SUCCESS_CREATE_DIARY("일기 생성 성공"),
 	SUCCESS_GET_DIARY("일기 상세 조회 성공"),
+	SUCCESS_UPDATE_DAIRY("일기 수정 성공"),
 
 	// message
 	SUCCESS_PUSH_MESSAGE("푸시알람 요청 성공");


### PR DESCRIPTION


## Related issue 🚀
- closed #52 

## Work Description 💚
- 일기 수정 기능을 구현했습니다.
- 수정할 경우, updatedAt 값도 업데이트 됩니다.
- Service 파일에 @Transactional(readOnly=true) 추가하고, 추가 및 수정 메소드에 @Transactional 어노테이션 추가했습니다.