### PR TITLE
[FEAT] 일기 삭제 API 구현

### DIFF
--- a/src/main/java/com/smeme/server/controller/DiaryController.java
+++ b/src/main/java/com/smeme/server/controller/DiaryController.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.security.Principal;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -51,6 +52,12 @@ public class DiaryController {
 		@PathVariable Long diaryId, @RequestBody DiaryRequestDTO requestDTO) {
 		diaryService.updateDiary(diaryId, requestDTO);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_DAIRY.getMessage()));
+	}
+
+	@DeleteMapping("/{diaryId}")
+	public ResponseEntity<ApiResponse> deleteDiary(@PathVariable Long diaryId) {
+		diaryService.deleteDiary(diaryId);
+		return ResponseEntity.ok(ApiResponse.success(SUCCESS_DELETE_DIARY.getMessage()));
 	}
 
 	private Long getMemberId(Principal principal) {

--- a/src/main/java/com/smeme/server/controller/ErrorHandler.java
+++ b/src/main/java/com/smeme/server/controller/ErrorHandler.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.webjars.NotFoundException;
 
 import com.smeme.server.util.ApiResponse;
 
@@ -15,7 +16,12 @@ public class ErrorHandler {
 
 	@ExceptionHandler(EntityNotFoundException.class)
 	public ResponseEntity<ApiResponse> EntityNotFoundException(EntityNotFoundException ex) {
-		return ResponseEntity.status(BAD_REQUEST).body(ApiResponse.fail(ex.getMessage()));
+		return ResponseEntity.status(NOT_FOUND).body(ApiResponse.fail(ex.getMessage()));
+	}
+
+	@ExceptionHandler(NotFoundException.class)
+	public ResponseEntity<ApiResponse> NotFoundException(NotFoundException ex) {
+		return ResponseEntity.status(NOT_FOUND).body(ApiResponse.fail(ex.getMessage()));
 	}
 
 	@ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/smeme/server/model/Diary.java
+++ b/src/main/java/com/smeme/server/model/Diary.java
@@ -74,6 +74,7 @@ public class Diary {
 
     public void deleteDiary() {
         this.isDeleted = true;
+        this.updatedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
     }
 
     private void setMember(Member member) {

--- a/src/main/java/com/smeme/server/model/Diary.java
+++ b/src/main/java/com/smeme/server/model/Diary.java
@@ -64,7 +64,7 @@ public class Diary {
         this.isDeleted = false;
         this.topic = topic;
         setMember(member);
-        this.createdAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.createdAt = LocalDateTime.now();
     }
 
     public void updateContent(String content) {
@@ -74,7 +74,7 @@ public class Diary {
 
     public void deleteDiary() {
         this.isDeleted = true;
-        this.updatedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.updatedAt = LocalDateTime.now();
     }
 
     private void setMember(Member member) {

--- a/src/main/java/com/smeme/server/model/Diary.java
+++ b/src/main/java/com/smeme/server/model/Diary.java
@@ -72,6 +72,10 @@ public class Diary {
         this.updatedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
     }
 
+    public void deleteDiary() {
+        this.isDeleted = true;
+    }
+
     private void setMember(Member member) {
         if (Objects.nonNull(this.member)) {
             this.member.getDiaries().remove(this);

--- a/src/main/java/com/smeme/server/repository/diary/DiaryRepositoryImpl.java
+++ b/src/main/java/com/smeme/server/repository/diary/DiaryRepositoryImpl.java
@@ -20,7 +20,7 @@ public class DiaryRepositoryImpl implements DiaryCustomRepository {
 
 	@Override
 	public boolean existTodayDiary(Member member) {
-		LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+		LocalDateTime now = LocalDateTime.now();
 		return queryFactory
 			.from(diary)
 			.where(

--- a/src/main/java/com/smeme/server/service/DiaryService.java
+++ b/src/main/java/com/smeme/server/service/DiaryService.java
@@ -5,6 +5,7 @@ import static java.util.Objects.*;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.webjars.NotFoundException;
 
 import com.smeme.server.dto.diary.DiaryRequestDTO;
 import com.smeme.server.dto.diary.DiaryResponseDTO;
@@ -49,9 +50,19 @@ public class DiaryService {
 		diary.updateContent(requestDTO.content());
 	}
 
+	@Transactional
+	public void deleteDiary(Long diaryId) {
+		Diary diary = getDiary(diaryId);
+		diary.deleteDiary();
+	}
+
 	private Diary getDiary(Long diaryId) {
-		return diaryRepository.findById(diaryId)
+		Diary diary = diaryRepository.findById(diaryId)
 			.orElseThrow(() -> new EntityNotFoundException(INVALID_DIARY.getMessage()));
+		if (diary.isDeleted()) {
+			throw new NotFoundException(DELETED_DIARY.getMessage());
+		}
+		return diary;
 	}
 
 	private Member getMember(Long memberId) {

--- a/src/main/java/com/smeme/server/util/message/ErrorMessage.java
+++ b/src/main/java/com/smeme/server/util/message/ErrorMessage.java
@@ -15,6 +15,7 @@ public enum ErrorMessage {
 	// diary
 	EXIST_TODAY_DIARY("일기는 하루에 한 번씩 작성할 수 있습니다."),
 	INVALID_DIARY("유효하지 않은 일기입니다."),
+	DELETED_DIARY("삭제된 일기입니다."),
 
 	// topic
 	INVALID_TOPIC("유효하지 않은 랜덤주제입니다.")

--- a/src/main/java/com/smeme/server/util/message/ResponseMessage.java
+++ b/src/main/java/com/smeme/server/util/message/ResponseMessage.java
@@ -10,6 +10,7 @@ public enum ResponseMessage {
 	SUCCESS_CREATE_DIARY("일기 생성 성공"),
 	SUCCESS_GET_DIARY("일기 상세 조회 성공"),
 	SUCCESS_UPDATE_DAIRY("일기 수정 성공"),
+	SUCCESS_DELETE_DIARY("일기 삭제 성공"),
 
 	// message
 	SUCCESS_PUSH_MESSAGE("푸시알람 요청 성공");


### PR DESCRIPTION


## Related issue 🚀
- closed #53 

## Work Description 💚
- 일기 삭제 기능 구현했습니다.
- 서비스 정책대로 Sofe Delete를 위해 isDelete = true 업데이트로 기능 구현했습니다.
- 에러핸들러에서 BAD_REQUEST -> NOT_FOUND 상태 값으로 하나 변경 및 추가했습니다.
- Default TimeZone 반영했습니다.
- 삭제된 일기(diary.isDeleted=true)는 조회 기능에서 호출되지 않도록 추가 처리했습니다.