### PR TITLE
[FEAT] 일기 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/smeme/server/controller/DiaryController.java
+++ b/src/main/java/com/smeme/server/controller/DiaryController.java
@@ -13,9 +13,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import com.smeme.server.dto.diary.DiariesResponseDTO;
 import com.smeme.server.dto.diary.DiaryRequestDTO;
 import com.smeme.server.dto.diary.DiaryResponseDTO;
 import com.smeme.server.service.DiaryService;
@@ -57,6 +59,13 @@ public class DiaryController {
 	public ResponseEntity<ApiResponse> deleteDiary(@PathVariable Long diaryId) {
 		diaryService.deleteDiary(diaryId);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_DELETE_DIARY.getMessage()));
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiResponse> getDiaries(Principal principal,
+		@RequestParam(name = "start") String startDate, @RequestParam(name = "end") String endDate) {
+		DiariesResponseDTO response = diaryService.getDiaries(Util.getMemberId(principal), startDate, endDate);
+		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_DIARIES.getMessage(), response));
 	}
 
 	private URI getURI(Long diaryId) {

--- a/src/main/java/com/smeme/server/dto/diary/DiariesResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/diary/DiariesResponseDTO.java
@@ -1,0 +1,30 @@
+package com.smeme.server.dto.diary;
+
+import java.util.List;
+
+import com.smeme.server.model.Diary;
+import com.smeme.server.util.Util;
+
+public record DiariesResponseDTO(
+	List<DiaryDTO> diaries,
+	boolean has30Past
+) {
+	public static DiariesResponseDTO of(List<Diary> diaries, boolean has30Past) {
+		return new DiariesResponseDTO(
+			diaries.stream().map(DiaryDTO::of).toList(),
+			has30Past
+		);
+	}
+}
+
+record DiaryDTO(
+	Long diaryId,
+	String content,
+	String createdAt
+) {
+	public static DiaryDTO of(Diary diary) {
+		return new DiaryDTO(diary.getId(),
+			diary.getContent(),
+			Util.transferDateTimeToString(diary.getCreatedAt()));
+	}
+}

--- a/src/main/java/com/smeme/server/repository/diary/DiaryCustomRepository.java
+++ b/src/main/java/com/smeme/server/repository/diary/DiaryCustomRepository.java
@@ -1,7 +1,13 @@
 package com.smeme.server.repository.diary;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.smeme.server.model.Diary;
 import com.smeme.server.model.Member;
 
 public interface DiaryCustomRepository {
 	boolean existTodayDiary(Member member);
+	List<Diary> findDiariesStartToEnd(Member member, LocalDateTime startDate, LocalDateTime endDate);
+	boolean exist30PastDiary(Member member);
 }

--- a/src/main/java/com/smeme/server/repository/diary/DiaryRepositoryImpl.java
+++ b/src/main/java/com/smeme/server/repository/diary/DiaryRepositoryImpl.java
@@ -3,11 +3,12 @@ package com.smeme.server.repository.diary;
 import static com.smeme.server.model.QDiary.*;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.smeme.server.model.Diary;
 import com.smeme.server.model.Member;
 
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,34 @@ public class DiaryRepositoryImpl implements DiaryCustomRepository {
 				diary.createdAt.between(get12midnight(now), now)
 			)
 			.select(diary.id)
+			.fetchFirst() != null;
+	}
+
+	@Override
+	public List<Diary> findDiariesStartToEnd(Member member, LocalDateTime startDate, LocalDateTime endDate) {
+		return queryFactory
+			.select(diary)
+			.from(diary)
+			.where(
+				diary.member.eq(member),
+				diary.createdAt.between(get12midnight(startDate), get12midnight(endDate)),
+				diary.isDeleted.eq(false)
+				)
+			.fetch();
+	}
+
+	@Override
+	public boolean exist30PastDiary(Member member) {
+		LocalDateTime past = LocalDateTime.now().minusDays(30);
+		return queryFactory
+			.select(diary)
+			.from(diary)
+			.where(
+				diary.member.eq(member),
+				diary.createdAt.year().eq(past.getYear()),
+				diary.createdAt.month().eq(past.getMonthValue()),
+				diary.createdAt.dayOfMonth().eq(past.getDayOfMonth())
+			)
 			.fetchFirst() != null;
 	}
 

--- a/src/main/java/com/smeme/server/service/DiaryService.java
+++ b/src/main/java/com/smeme/server/service/DiaryService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.webjars.NotFoundException;
 
+import com.smeme.server.dto.diary.DiariesResponseDTO;
 import com.smeme.server.dto.diary.DiaryRequestDTO;
 import com.smeme.server.dto.diary.DiaryResponseDTO;
 import com.smeme.server.model.Correction;
@@ -19,6 +20,7 @@ import com.smeme.server.repository.CorrectionRepository;
 import com.smeme.server.repository.diary.DiaryRepository;
 import com.smeme.server.repository.MemberRepository;
 import com.smeme.server.repository.TopicRepository;
+import com.smeme.server.util.Util;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -60,6 +62,15 @@ public class DiaryService {
 	public void deleteDiary(Long diaryId) {
 		Diary diary = getDiary(diaryId);
 		diary.deleteDiary();
+	}
+
+	public DiariesResponseDTO getDiaries(Long memberId, String startDate, String endDate) {
+		Member member = getMember(memberId);
+		List<Diary> diaries = diaryRepository.findDiariesStartToEnd(member,
+			Util.transferStringToDateTime(startDate),
+			Util.transferStringToDateTime(endDate));
+		boolean has30Past = diaryRepository.exist30PastDiary(member);
+		return DiariesResponseDTO.of(diaries, has30Past);
 	}
 
 	private Diary getDiary(Long diaryId) {

--- a/src/main/java/com/smeme/server/util/Util.java
+++ b/src/main/java/com/smeme/server/util/Util.java
@@ -4,6 +4,8 @@ import static com.smeme.server.util.message.ErrorMessage.*;
 import static java.util.Objects.*;
 
 import java.security.Principal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public class Util {
 
@@ -12,5 +14,13 @@ public class Util {
 			throw new SecurityException(EMPTY_ACCESS_TOKEN.getMessage());
 		}
 		return Long.valueOf(principal.getName());
+	}
+
+	public static String transferDateTimeToString(LocalDateTime dateTime) {
+		return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+	}
+
+	public static LocalDateTime transferStringToDateTime(String str) {
+		return LocalDateTime.parse(str + " 00:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
 	}
 }

--- a/src/main/java/com/smeme/server/util/message/ResponseMessage.java
+++ b/src/main/java/com/smeme/server/util/message/ResponseMessage.java
@@ -11,6 +11,7 @@ public enum ResponseMessage {
 	SUCCESS_GET_DIARY("일기 상세 조회 성공"),
 	SUCCESS_UPDATE_DAIRY("일기 수정 성공"),
 	SUCCESS_DELETE_DIARY("일기 삭제 성공"),
+	SUCCESS_GET_DIARIES("일기 리스트 조회 성공"),
 
 	// message
 	SUCCESS_PUSH_MESSAGE("푸시알람 요청 성공");


### PR DESCRIPTION


## Related issue 🚀
- closed #61 

## Work Description 💚
- 일기 목록 조회 기능 구현했습니다.
- startDate(start 쿼리 값)와 endDate(end 쿼리 값) 사이의 diary 데이터를 조회합니다.
- 30일 전의 일기가 존재하는 지 여부를 판단합니다.