### PR TITLE
[FEAT] 랜덤주제 조회 API 기능 구현

### DIFF
--- a/src/main/java/com/smeme/server/controller/TopicController.java
+++ b/src/main/java/com/smeme/server/controller/TopicController.java
@@ -1,0 +1,28 @@
+package com.smeme.server.controller;
+
+import static com.smeme.server.util.message.ResponseMessage.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.smeme.server.dto.topic.TopicResponseDTO;
+import com.smeme.server.service.TopicService;
+import com.smeme.server.util.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/topics")
+public class TopicController {
+
+	private final TopicService topicService;
+
+	@GetMapping("/random")
+	public ResponseEntity<ApiResponse> getRandomTopic() {
+		TopicResponseDTO response = topicService.getRandomTopic();
+		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_RANDOM_TOPIC.getMessage(), response));
+	}
+}

--- a/src/main/java/com/smeme/server/dto/topic/TopicResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/topic/TopicResponseDTO.java
@@ -1,0 +1,9 @@
+package com.smeme.server.dto.topic;
+
+import com.smeme.server.model.topic.Topic;
+
+public record TopicResponseDTO(Long topicId, String content) {
+	public static TopicResponseDTO of (Topic topic) {
+		return new TopicResponseDTO(topic.getId(), topic.getContent());
+	}
+}

--- a/src/main/java/com/smeme/server/repository/TopicRepository.java
+++ b/src/main/java/com/smeme/server/repository/TopicRepository.java
@@ -1,8 +1,0 @@
-package com.smeme.server.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.smeme.server.model.topic.Topic;
-
-public interface TopicRepository extends JpaRepository<Topic, Long> {
-}

--- a/src/main/java/com/smeme/server/repository/topic/TopicCustomRepository.java
+++ b/src/main/java/com/smeme/server/repository/topic/TopicCustomRepository.java
@@ -1,0 +1,7 @@
+package com.smeme.server.repository.topic;
+
+import com.smeme.server.model.topic.Topic;
+
+public interface TopicCustomRepository {
+	Topic getRandomTopic();
+}

--- a/src/main/java/com/smeme/server/repository/topic/TopicRepository.java
+++ b/src/main/java/com/smeme/server/repository/topic/TopicRepository.java
@@ -1,0 +1,8 @@
+package com.smeme.server.repository.topic;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.smeme.server.model.topic.Topic;
+
+public interface TopicRepository extends JpaRepository<Topic, Long>, TopicCustomRepository {
+}

--- a/src/main/java/com/smeme/server/repository/topic/TopicRepositoryImpl.java
+++ b/src/main/java/com/smeme/server/repository/topic/TopicRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.smeme.server.repository.topic;
+
+import static com.querydsl.core.types.dsl.NumberExpression.*;
+import static com.smeme.server.model.topic.QTopic.*;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.smeme.server.model.topic.Topic;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class TopicRepositoryImpl implements TopicCustomRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Topic getRandomTopic() {
+		return queryFactory
+			.select(topic)
+			.from(topic)
+			.orderBy(random().asc())
+			.limit(1)
+			.fetchFirst();
+	}
+}

--- a/src/main/java/com/smeme/server/service/DiaryService.java
+++ b/src/main/java/com/smeme/server/service/DiaryService.java
@@ -21,7 +21,7 @@ import com.smeme.server.model.topic.Topic;
 import com.smeme.server.repository.CorrectionRepository;
 import com.smeme.server.repository.diary.DiaryRepository;
 import com.smeme.server.repository.MemberRepository;
-import com.smeme.server.repository.TopicRepository;
+import com.smeme.server.repository.topic.TopicRepository;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/smeme/server/service/TopicService.java
+++ b/src/main/java/com/smeme/server/service/TopicService.java
@@ -1,0 +1,23 @@
+package com.smeme.server.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.smeme.server.dto.topic.TopicResponseDTO;
+import com.smeme.server.model.topic.Topic;
+import com.smeme.server.repository.topic.TopicRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TopicService {
+
+	private final TopicRepository topicRepository;
+
+	public TopicResponseDTO getRandomTopic() {
+		Topic topic = topicRepository.getRandomTopic();
+		return TopicResponseDTO.of(topic);
+	}
+}

--- a/src/main/java/com/smeme/server/util/message/ResponseMessage.java
+++ b/src/main/java/com/smeme/server/util/message/ResponseMessage.java
@@ -13,6 +13,9 @@ public enum ResponseMessage {
 	SUCCESS_DELETE_DIARY("일기 삭제 성공"),
 	SUCCESS_GET_DIARIES("일기 리스트 조회 성공"),
 
+	// topic
+	SUCCESS_GET_RANDOM_TOPIC("랜덤 주제 조회 성공"),
+
 	// correction
 	SUCCESS_CREATE_CORRECTION("일기 첨삭 성공"),
 	SUCCESS_DELETE_CORRECTION("첨삭 삭제 성공"),


### PR DESCRIPTION


## Related issue 🚀
- closed #69 

## Work Description 💚
- 랜덤 주제 조회 API 기능을 구현했습니다.
- TopicRepository 관련 QueryDSL을 추가하면서 package 추가 및 기존 TopicRepository 파일을 패키지 내로 위치 이동했습니다.
- 후에 랜덤주제 전체 조회 기능의 가능성을 생각하여 해당 uri를 `/api/v2/topics/random` 으로 변경했습니다. (+노션 반영)