### PR TITLE
[FEAT] 회원가입 (유저정보 설정 API 구현)

### DIFF
--- a/src/main/java/com/smeme/server/controller/ErrorHandler.java
+++ b/src/main/java/com/smeme/server/controller/ErrorHandler.java
@@ -2,6 +2,8 @@ package com.smeme.server.controller;
 
 import static org.springframework.http.HttpStatus.*;
 
+import jakarta.persistence.EntityExistsException;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -26,6 +28,16 @@ public class ErrorHandler {
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ApiResponse> IllegalArgumentException(IllegalArgumentException ex) {
+		return ResponseEntity.status(BAD_REQUEST).body(ApiResponse.fail(ex.getMessage()));
+	}
+
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ApiResponse> ConstraintViolationException(ConstraintViolationException ex) {
+		return ResponseEntity.status(BAD_REQUEST).body(ApiResponse.fail(ex.getMessage()));
+	}
+
+	@ExceptionHandler(EntityExistsException.class)
+	public ResponseEntity<ApiResponse> EntityExistsException(EntityExistsException ex) {
 		return ResponseEntity.status(BAD_REQUEST).body(ApiResponse.fail(ex.getMessage()));
 	}
 }

--- a/src/main/java/com/smeme/server/controller/MemberController.java
+++ b/src/main/java/com/smeme/server/controller/MemberController.java
@@ -18,7 +18,7 @@ import static com.smeme.server.util.message.ResponseMessage.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v2/member")
+@RequestMapping("/api/v2/members")
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/com/smeme/server/controller/MemberController.java
+++ b/src/main/java/com/smeme/server/controller/MemberController.java
@@ -1,2 +1,33 @@
-package com.smeme.server.controller;public class MemberController {
+package com.smeme.server.controller;
+
+import com.smeme.server.dto.member.UpdateMemberRequestDTO;
+import com.smeme.server.service.MemberService;
+import com.smeme.server.util.ApiResponse;
+import com.smeme.server.util.Util;
+import com.smeme.server.util.message.ResponseMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+import static com.smeme.server.util.message.ResponseMessage.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PatchMapping()
+    public ResponseEntity<ApiResponse> updateUserProfile(
+            Principal principal, @RequestBody UpdateMemberRequestDTO requestDTO) {
+        memberService.updateMember(Util.getMemberId(principal), requestDTO);
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USERNAME.getMessage()));
+    }
+
 }

--- a/src/main/java/com/smeme/server/controller/MemberController.java
+++ b/src/main/java/com/smeme/server/controller/MemberController.java
@@ -1,0 +1,2 @@
+package com.smeme.server.controller;public class MemberController {
+}

--- a/src/main/java/com/smeme/server/dto/member/UpdateMemberRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/UpdateMemberRequestDTO.java
@@ -2,6 +2,7 @@ package com.smeme.server.dto.member;
 
 public record UpdateMemberRequestDTO(
         @ValidUsername
-        String username
+        String username,
+        boolean termAccepted
 ) {
 }

--- a/src/main/java/com/smeme/server/dto/member/UpdateMemberRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/UpdateMemberRequestDTO.java
@@ -1,2 +1,7 @@
-package com.smeme.server.dto.member;public record UpdateMemberRequestDTO() {
+package com.smeme.server.dto.member;
+
+public record UpdateMemberRequestDTO(
+        @ValidUsername
+        String username
+) {
 }

--- a/src/main/java/com/smeme/server/dto/member/UpdateMemberRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/UpdateMemberRequestDTO.java
@@ -1,0 +1,2 @@
+package com.smeme.server.dto.member;public record UpdateMemberRequestDTO() {
+}

--- a/src/main/java/com/smeme/server/dto/member/UsernameValidator.java
+++ b/src/main/java/com/smeme/server/dto/member/UsernameValidator.java
@@ -1,0 +1,28 @@
+package com.smeme.server.dto.member;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class UsernameValidator implements ConstraintValidator<ValidUsername, String> {
+
+    @Override
+    public void initialize(ValidUsername constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(String username, ConstraintValidatorContext context) {
+        if (username == null || username.isEmpty()) {
+            return false;
+        }
+
+        if (username.length() < 1 || username.length() > 10) {
+            return false;
+        }
+
+        if (username.charAt(0) == ' ') {
+            return false;
+        }
+
+        return username.trim().isEmpty();
+    }
+}

--- a/src/main/java/com/smeme/server/dto/member/UsernameValidator.java
+++ b/src/main/java/com/smeme/server/dto/member/UsernameValidator.java
@@ -11,18 +11,17 @@ public class UsernameValidator implements ConstraintValidator<ValidUsername, Str
 
     @Override
     public boolean isValid(String username, ConstraintValidatorContext context) {
-        if (username == null || username.isEmpty()) {
+
+        // null, 공백으로만 이뤄지는 경우, 빈 값인 경우 ''
+        if (username.isBlank()) {
             return false;
         }
 
+        // 길이가 1보다 작거나 10보다 큰 경우
         if (username.length() < 1 || username.length() > 10) {
             return false;
         }
-
-        if (username.charAt(0) == ' ') {
-            return false;
-        }
-
-        return username.trim().isEmpty();
+        // 첫 글자가 공백인 경우
+        return !(username.charAt(0) == ' ');
     }
 }

--- a/src/main/java/com/smeme/server/dto/member/ValidUsername.java
+++ b/src/main/java/com/smeme/server/dto/member/ValidUsername.java
@@ -1,0 +1,16 @@
+package com.smeme.server.dto.member;
+
+import com.smeme.server.util.message.ErrorMessage;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = UsernameValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidUsername {
+
+    String message() default "닉네임 제한사항에 부합하지 않습니다.";
+}

--- a/src/main/java/com/smeme/server/model/Member.java
+++ b/src/main/java/com/smeme/server/model/Member.java
@@ -40,9 +40,19 @@ public class Member {
     @Column(length = 10, unique = true)
     private String username;
 
+    @Column(name="fcm_token")
+    private String fcmToken;
+
+    @Column(name="term_accepted")
+    private boolean termAcceped;
+
+
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private LangType targetLang;
+
+    @Column(name = "terms_agreed", nullable = false)
+    private boolean termsAgreed;
 
     @OneToMany(mappedBy = "member")
     private final List<TrainingTime> trainingTimes = new ArrayList<>();
@@ -67,4 +77,6 @@ public class Member {
     }
 
     public void updateUsername(String username) { this.username = username; }
+
+    public void updateTermAccepted(boolean termAccepted) { this.termAcceped = termAccepted; }
 }

--- a/src/main/java/com/smeme/server/model/Member.java
+++ b/src/main/java/com/smeme/server/model/Member.java
@@ -40,10 +40,8 @@ public class Member {
     @Column(length = 10, unique = true)
     private String username;
 
-    @Column(name="fcm_token")
     private String fcmToken;
 
-    @Column(name="term_accepted")
     private boolean termAccepted;
 
     @Column(nullable = false)

--- a/src/main/java/com/smeme/server/model/Member.java
+++ b/src/main/java/com/smeme/server/model/Member.java
@@ -3,7 +3,6 @@ package com.smeme.server.model;
 import static jakarta.persistence.GenerationType.*;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -66,4 +65,6 @@ public class Member {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
+    public void updateUsername(String username) { this.username = username; }
 }

--- a/src/main/java/com/smeme/server/model/Member.java
+++ b/src/main/java/com/smeme/server/model/Member.java
@@ -44,15 +44,11 @@ public class Member {
     private String fcmToken;
 
     @Column(name="term_accepted")
-    private boolean termAcceped;
-
+    private boolean termAccepted;
 
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private LangType targetLang;
-
-    @Column(name = "terms_agreed", nullable = false)
-    private boolean termsAgreed;
 
     @OneToMany(mappedBy = "member")
     private final List<TrainingTime> trainingTimes = new ArrayList<>();
@@ -78,5 +74,5 @@ public class Member {
 
     public void updateUsername(String username) { this.username = username; }
 
-    public void updateTermAccepted(boolean termAccepted) { this.termAcceped = termAccepted; }
+    public void updateTermAccepted(boolean termAccepted) { this.termAccepted = termAccepted; }
 }

--- a/src/main/java/com/smeme/server/repository/MemberRepository.java
+++ b/src/main/java/com/smeme/server/repository/MemberRepository.java
@@ -12,4 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsBySocialAndSocialId(SocialType socialType, String socialId);
 
     Optional<Member> findBySocialAndSocialId(SocialType social, String socialId);
+
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -1,2 +1,38 @@
-package com.smeme.server.service;public class MemberService {
+package com.smeme.server.service;
+
+import com.smeme.server.dto.member.UpdateMemberRequestDTO;
+import com.smeme.server.model.Member;
+import com.smeme.server.repository.MemberRepository;
+import com.smeme.server.util.message.ErrorMessage;
+import jakarta.persistence.EntityExistsException;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void updateMember(Long memberId, UpdateMemberRequestDTO dto) {
+        checkMemberDuplicate(dto.username());
+        Member member = getMemberById(memberId);
+        member.updateUsername(dto.username());
+        memberRepository.save(member);
+    }
+
+    private Member getMemberById(Long id) {
+        return memberRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException(ErrorMessage.EMPTY_MEMBER.getMessage()));
+    }
+
+    private void checkMemberDuplicate(String username) {
+        if (memberRepository.existsByUsername(username)) {
+            throw new EntityExistsException(ErrorMessage.DUPLICATE_USERNAME.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -23,7 +23,6 @@ public class MemberService {
         Member member = getMemberById(memberId);
         member.updateUsername(dto.username());
         member.updateTermAccepted(dto.termAccepted());
-        memberRepository.save(member);
     }
 
     private Member getMemberById(Long id) {

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -22,6 +22,7 @@ public class MemberService {
         checkMemberDuplicate(dto.username());
         Member member = getMemberById(memberId);
         member.updateUsername(dto.username());
+        member.updateTermAccepted(dto.termAccepted());
         memberRepository.save(member);
     }
 

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -1,0 +1,2 @@
+package com.smeme.server.service;public class MemberService {
+}

--- a/src/main/java/com/smeme/server/util/message/ErrorMessage.java
+++ b/src/main/java/com/smeme/server/util/message/ErrorMessage.java
@@ -13,7 +13,10 @@ public enum ErrorMessage {
   INVALID_TOKEN("유효하지 않은 토큰입니다"),
 
 	// member
+	EMPTY_MEMBER("존재하지 않는 회원입니다."),
+	DUPLICATE_USERNAME("이미 존재하는 닉네임입니다."),
 	INVALID_MEMBER("유효하지 않은 회원입니다."),
+	INVALID_USERNAME("유효하지 않은 닉네임입니다."),
 
 	// diary
 	EXIST_TODAY_DIARY("일기는 하루에 한 번씩 작성할 수 있습니다."),

--- a/src/main/java/com/smeme/server/util/message/ResponseMessage.java
+++ b/src/main/java/com/smeme/server/util/message/ResponseMessage.java
@@ -16,6 +16,9 @@ public enum ResponseMessage {
 	// correction
 	SUCCESS_CREATE_CORRECTION("일기 첨삭 성공"),
 
+	// member
+	SUCCESS_UPDATE_USERNAME("닉네임 변경 성공"),
+
 	// message
 	SUCCESS_PUSH_MESSAGE("푸시알람 요청 성공"),
 


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #29 

## Work Description 💚
- 유저정보 설정 API 구현
- Member에 이용약관 동의 termAccepted 필드 추가 -> API 로직 추가
- 요청에 따라 Member에 fcm_token 추가