### PR TITLE
[FEAT] 임시토큰 발급 API

### DIFF
--- a/src/main/java/com/smeme/server/config/SecurityConfig.java
+++ b/src/main/java/com/smeme/server/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
     private static final String[] AUTH_WHITELIST = {
             "/api/v2/auth",
             "/api/v2/test",
+            "/api/beta/token",
             "/v3/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html",

--- a/src/main/java/com/smeme/server/controller/BadgeController.java
+++ b/src/main/java/com/smeme/server/controller/BadgeController.java
@@ -3,11 +3,9 @@ package com.smeme.server.controller;
 import com.smeme.server.service.BadgeService;
 import com.smeme.server.util.ApiResponse;
 import com.smeme.server.util.Util;
-import com.smeme.server.util.message.ResponseMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/smeme/server/controller/BetaAuthController.java
+++ b/src/main/java/com/smeme/server/controller/BetaAuthController.java
@@ -1,0 +1,27 @@
+package com.smeme.server.controller;
+
+import com.smeme.server.service.auth.BetaAuthService;
+import com.smeme.server.util.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.smeme.server.util.message.ResponseMessage.*;
+
+/*
+베타 테스트에 진행할 임시 토큰 발급 API를 구현하는 class입니다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/beta")
+public class BetaAuthController {
+
+    private final BetaAuthService betaAuthService;
+
+    @PostMapping("/token")
+    public ResponseEntity<ApiResponse> getToken() {
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_BETA_AUTH_TOKEN.getMessage(), betaAuthService.createBetaMember()));
+    }
+}

--- a/src/main/java/com/smeme/server/dto/auth/beta/BetaTokenResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/auth/beta/BetaTokenResponseDTO.java
@@ -1,0 +1,9 @@
+package com.smeme.server.dto.auth.beta;
+
+public record BetaTokenResponseDTO(
+        String accessToken
+) {
+    public static BetaTokenResponseDTO of(String accessToken) {
+        return new BetaTokenResponseDTO(accessToken);
+    }
+}

--- a/src/main/java/com/smeme/server/model/SocialType.java
+++ b/src/main/java/com/smeme/server/model/SocialType.java
@@ -1,5 +1,5 @@
 package com.smeme.server.model;
 
 public enum SocialType {
-    KAKAO, APPLE
+    KAKAO, APPLE, BETA
 }

--- a/src/main/java/com/smeme/server/service/auth/BetaAuthService.java
+++ b/src/main/java/com/smeme/server/service/auth/BetaAuthService.java
@@ -1,0 +1,60 @@
+package com.smeme.server.service.auth;
+
+import com.smeme.server.config.jwt.JwtTokenProvider;
+import com.smeme.server.config.jwt.UserAuthentication;
+import com.smeme.server.dto.auth.beta.BetaTokenResponseDTO;
+import com.smeme.server.model.Member;
+import com.smeme.server.model.badge.Badge;
+import com.smeme.server.model.badge.MemberBadge;
+import com.smeme.server.repository.MemberRepository;
+import com.smeme.server.repository.badge.BadgeRepository;
+import com.smeme.server.repository.badge.MemberBadgeRepository;
+import com.smeme.server.util.message.ErrorMessage;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.smeme.server.model.LangType.*;
+import static com.smeme.server.model.SocialType.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BetaAuthService {
+
+    private final MemberRepository memberRepository;
+    private final MemberBadgeRepository memberBadgeRepository;
+    private final JwtTokenProvider tokenProvider;
+    private final BadgeRepository badgeRepository;
+
+    @Value("${badge.welcome-badge-id}")
+    private Long WELCOME_BADGE_ID;
+    private static final Long BETA_USER_EXPIRED = 60 * 60 * 1000 * 24 * 21L;
+
+    @Transactional
+    public BetaTokenResponseDTO createBetaMember() {
+
+        AtomicInteger atomicInteger = new AtomicInteger(1);
+        Member betaMember = Member.builder()
+                .social(BETA)
+                .targetLang(en)
+                .socialId("beta" + atomicInteger.getAndIncrement())
+                .build();
+        memberRepository.save(betaMember);
+        addWelcomeBadge(betaMember);
+        Authentication authentication = new UserAuthentication(betaMember.getId(), null, null);
+        return BetaTokenResponseDTO.of(tokenProvider.generateToken(authentication, BETA_USER_EXPIRED));
+    }
+
+    private void addWelcomeBadge(Member member) {
+        Badge badge = badgeRepository.findById(WELCOME_BADGE_ID).orElseThrow(
+                () -> new EntityNotFoundException(ErrorMessage.EMPTY_BADGE.getMessage())
+        );
+        memberBadgeRepository.save(new MemberBadge(member, badge));
+    }
+}

--- a/src/main/java/com/smeme/server/util/message/ResponseMessage.java
+++ b/src/main/java/com/smeme/server/util/message/ResponseMessage.java
@@ -36,7 +36,11 @@ public enum ResponseMessage {
 	SUCCESS_SIGNOUT("로그아웃 성공"),
 
 	// jwt
-	SUCCESS_ISSUE_TOKEN("토큰 발급 성공");
+	SUCCESS_ISSUE_TOKEN("토큰 발급 성공"),
+
+	// beta
+	SUCCESS_BETA_AUTH_TOKEN("임시토큰 발급 성공")
+	;
 
 	private final String message;
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #106 

## Work Description 💚
- 임시 토큰 API 발급 해주는 API를 구현했습니다.
- 만료 기간은 3주로 설정했습니다.

```JSON
{
    "success": true,
    "message": "임시토큰 발급 성공",
    "data": {
        "accessToken": "~"
    }
}
```