### PR TITLE
[REFACTOR] 학습 계획 설정 API 개선

### DIFF
--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -18,12 +18,14 @@ import com.smeme.server.repository.trainingTime.TrainingTimeRepository;
 import com.smeme.server.util.message.ErrorMessage;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 
@@ -63,10 +65,13 @@ public class MemberService {
     @Transactional
     public void updateMemberPlan(Long memberId, MemberPlanUpdateRequestDTO requestDTO) {
         Member member = getMemberById(memberId);
-        trainingTimeRepository.deleteAll(member.getTrainingTimes());
         member.updateHasAlarm(requestDTO.hasAlarm());
         member.updateGoal(requestDTO.target());
+        if (!Objects.isNull(requestDTO.trainingTime())) updateMemberTrainingTime(member, requestDTO);
+    }
 
+    private void updateMemberTrainingTime(Member member, MemberPlanUpdateRequestDTO requestDTO) {
+        trainingTimeRepository.deleteAll(member.getTrainingTimes());
         for (String day : parseDay(requestDTO.trainingTime().day())) {
             TrainingTime trainingTime = TrainingTime.builder()
                     .day(DayType.valueOf(day))

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -65,9 +65,13 @@ public class MemberService {
     @Transactional
     public void updateMemberPlan(Long memberId, MemberPlanUpdateRequestDTO requestDTO) {
         Member member = getMemberById(memberId);
-        member.updateHasAlarm(requestDTO.hasAlarm());
-        member.updateGoal(requestDTO.target());
-        if (!Objects.isNull(requestDTO.trainingTime())) updateMemberTrainingTime(member, requestDTO);
+
+        if (!Objects.isNull(requestDTO.target())) member.updateGoal(requestDTO.target());
+
+        if (!Objects.isNull(requestDTO.trainingTime())) {
+            member.updateHasAlarm(requestDTO.hasAlarm());
+            updateMemberTrainingTime(member, requestDTO);
+        }
     }
 
     private void updateMemberTrainingTime(Member member, MemberPlanUpdateRequestDTO requestDTO) {


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #109 

## Work Description 💚
- 학습 계획 설정 API가 에서 null일 경우 request body에서 학습시간이 없는 경우, 학습 계획 설정만 설정하도록 수정

## Points Of Consider
- 베타 테스트 상에 API는 문제가 없으나, 릴리즈 시에 해당 API가 세 가지 상황을 커버 해야함.
1.  회원가입 시에,  초기 트레이닝 목표 설정 및 트레이닝 시간 설정
2. 마이페이지에서 트레이닝 목표 설정
3. 마이페이지에서 트레이닝 시간 설정

2번 , 3번 상황에서는 필요한 요청 외에는 null로 들어오는 request body data를 처리해줘야 하는데 좋은 설계인지?