### PR TITLE
[REFACTOR] beta test를 위한 API response 개선

### DIFF
--- a/src/main/java/com/smeme/server/controller/BetaAuthController.java
+++ b/src/main/java/com/smeme/server/controller/BetaAuthController.java
@@ -1,10 +1,12 @@
 package com.smeme.server.controller;
 
+import com.smeme.server.dto.auth.beta.BetaSignInRequestDTO;
 import com.smeme.server.service.auth.BetaAuthService;
 import com.smeme.server.util.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,7 +23,7 @@ public class BetaAuthController {
     private final BetaAuthService betaAuthService;
 
     @PostMapping("/token")
-    public ResponseEntity<ApiResponse> getToken() {
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_BETA_AUTH_TOKEN.getMessage(), betaAuthService.createBetaMember()));
+    public ResponseEntity<ApiResponse> getToken(@RequestBody BetaSignInRequestDTO betaSignInRequestDTO) {
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_BETA_AUTH_TOKEN.getMessage(), betaAuthService.createBetaMember(betaSignInRequestDTO)));
     }
 }

--- a/src/main/java/com/smeme/server/dto/auth/SignInRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/auth/SignInRequestDTO.java
@@ -4,6 +4,8 @@ package com.smeme.server.dto.auth;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.smeme.server.model.SocialType;
 public record SignInRequestDTO(
-        @JsonProperty("social")  SocialType socialType) {
-
+        @JsonProperty("social")
+        SocialType socialType,
+        String fcmToken
+        ) {
 }

--- a/src/main/java/com/smeme/server/dto/auth/SignInResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/auth/SignInResponseDTO.java
@@ -1,14 +1,19 @@
 package com.smeme.server.dto.auth;
 
 
+import com.smeme.server.dto.badge.BadgeResponseDTO;
 import lombok.Builder;
+
+import java.util.List;
 
 @Builder
 public record SignInResponseDTO(
         String accessToken,
         String refreshToken,
         boolean isRegistered,
-        boolean hasPlan
+        boolean hasPlan,
+
+        List<BadgeResponseDTO> badges
 ) {
 
 }

--- a/src/main/java/com/smeme/server/dto/auth/beta/BetaSignInRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/auth/beta/BetaSignInRequestDTO.java
@@ -1,0 +1,6 @@
+package com.smeme.server.dto.auth.beta;
+
+public record BetaSignInRequestDTO(
+        String fcmToken
+) {
+}

--- a/src/main/java/com/smeme/server/dto/auth/beta/BetaTokenResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/auth/beta/BetaTokenResponseDTO.java
@@ -2,11 +2,13 @@ package com.smeme.server.dto.auth.beta;
 
 import com.smeme.server.dto.badge.BadgeResponseDTO;
 
+import java.util.List;
+
 public record BetaTokenResponseDTO(
         String accessToken,
-        BadgeResponseDTO badge
+        List<BadgeResponseDTO> badges
 ) {
-    public static BetaTokenResponseDTO of(String accessToken, BadgeResponseDTO badge) {
-        return new BetaTokenResponseDTO(accessToken, badge);
+    public static BetaTokenResponseDTO of(String accessToken, List<BadgeResponseDTO> badges) {
+        return new BetaTokenResponseDTO(accessToken, badges);
     }
 }

--- a/src/main/java/com/smeme/server/dto/auth/beta/BetaTokenResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/auth/beta/BetaTokenResponseDTO.java
@@ -1,9 +1,12 @@
 package com.smeme.server.dto.auth.beta;
 
+import com.smeme.server.dto.badge.BadgeResponseDTO;
+
 public record BetaTokenResponseDTO(
-        String accessToken
+        String accessToken,
+        BadgeResponseDTO badge
 ) {
-    public static BetaTokenResponseDTO of(String accessToken) {
-        return new BetaTokenResponseDTO(accessToken);
+    public static BetaTokenResponseDTO of(String accessToken, BadgeResponseDTO badge) {
+        return new BetaTokenResponseDTO(accessToken, badge);
     }
 }

--- a/src/main/java/com/smeme/server/dto/member/MemberGetResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberGetResponseDTO.java
@@ -7,9 +7,9 @@ import com.smeme.server.model.goal.Goal;
 
 import java.util.List;
 
-public record MemberGetResponseDTO(String username, String target, String way, String detail, String targetLang, boolean hasPushAlarm, TrainingTimeResponseDTO trainingTime, List<BadgeResponseDTO> badges) {
+public record MemberGetResponseDTO(String username, String target, String way, String detail, String targetLang, boolean hasPushAlarm, TrainingTimeResponseDTO trainingTime, BadgeResponseDTO badge) {
 
-    public static MemberGetResponseDTO of(Goal goal,Member member, TrainingTimeResponseDTO trainingTime, List<BadgeResponseDTO> badges) {
+    public static MemberGetResponseDTO of(Goal goal,Member member, TrainingTimeResponseDTO trainingTime, BadgeResponseDTO badge) {
         return new MemberGetResponseDTO(
                 member.getUsername(),
                 member.getGoal().getDescription(),
@@ -18,7 +18,7 @@ public record MemberGetResponseDTO(String username, String target, String way, S
                 member.getTargetLang().toString(),
                 member.isHasPushAlarm(),
                 trainingTime,
-                badges
+                badge
         );
     }
 }

--- a/src/main/java/com/smeme/server/dto/member/MemberPushRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberPushRequestDTO.java
@@ -1,0 +1,2 @@
+package com.smeme.server.dto.member;public record MemberPushRequestDTO() {
+}

--- a/src/main/java/com/smeme/server/model/Member.java
+++ b/src/main/java/com/smeme/server/model/Member.java
@@ -60,12 +60,15 @@ public class Member {
 
 
     @Builder
-    public Member(SocialType social, String socialId, LangType targetLang) {
+    public Member(SocialType social, String socialId, LangType targetLang, String fcmToken) {
         this.social = social;
         this.socialId = socialId;
         this.targetLang = targetLang;
+        this.fcmToken = fcmToken;
         this.goal = null;
     }
+
+    public void updateFcmToken(String fcmToken) {this.fcmToken = fcmToken; }
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -12,6 +12,7 @@ import com.smeme.server.model.goal.Goal;
 import com.smeme.server.model.goal.GoalType;
 import com.smeme.server.model.training.DayType;
 import com.smeme.server.model.training.TrainingTime;
+import com.smeme.server.repository.badge.BadgeRepository;
 import com.smeme.server.repository.badge.MemberBadgeRepository;
 import com.smeme.server.repository.MemberRepository;
 import com.smeme.server.repository.goal.GoalRepository;
@@ -38,6 +39,7 @@ public class MemberService {
     private final TrainingTimeRepository trainingTimeRepository;
     private final MemberBadgeRepository memberBadgeRepository;
     private final GoalRepository goalRepository;
+    private final BadgeRepository badgeRepository;
 
     @Transactional
     public void updateMember(Long memberId, MemberUpdateRequestDTO dto) {
@@ -50,8 +52,6 @@ public class MemberService {
     public MemberGetResponseDTO getMember(Long memberId) {
         Member member = getMemberById(memberId);
         Goal goal = getGoal(member.getGoal());
-        List<BadgeResponseDTO> badges = new ArrayList<>();
-        badges.add(BadgeResponseDTO.of(getBadge(memberId)));
         List<TrainingTime> trainingTimeList = getTrainingTimeByMemberId(memberId);
         TrainingTime trainingTime = getOneTrainingTime(getTrainingTimeByMemberId(memberId));
         TrainingTimeResponseDTO trainingTimeResponseDTO = TrainingTimeResponseDTO.builder()
@@ -59,8 +59,9 @@ public class MemberService {
                                                             .hour(trainingTime.getHour())
                                                             .minute(trainingTime.getMinute())
                                                             .build();
-        return MemberGetResponseDTO.of(goal, member,trainingTimeResponseDTO , badges);
+        return MemberGetResponseDTO.of(goal, member,trainingTimeResponseDTO ,BadgeResponseDTO.of(getBadge(memberId)));
     }
+
 
     @Transactional
     public void updateMemberPlan(Long memberId, MemberPlanUpdateRequestDTO requestDTO) {

--- a/src/main/java/com/smeme/server/service/auth/BetaAuthService.java
+++ b/src/main/java/com/smeme/server/service/auth/BetaAuthService.java
@@ -19,6 +19,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.smeme.server.model.LangType.*;
@@ -50,7 +52,9 @@ public class BetaAuthService {
                 .build();
         memberRepository.save(betaMember);
         Authentication authentication = new UserAuthentication(betaMember.getId(), null, null);
-        return BetaTokenResponseDTO.of(tokenProvider.generateToken(authentication, BETA_USER_EXPIRED), BadgeResponseDTO.of(addWelcomeBadge(betaMember)));
+        List<BadgeResponseDTO> badges = new ArrayList<>();
+        badges.add(BadgeResponseDTO.of(addWelcomeBadge(betaMember)));
+        return BetaTokenResponseDTO.of(tokenProvider.generateToken(authentication, BETA_USER_EXPIRED), badges);
     }
 
     private Badge addWelcomeBadge(Member member) {


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #118 #117 

## Work Description 💚
- 임시토큰 발급하는 API에서 fcmToken을 받아 DB에 저장하는 로직 추가
- 임시토큰 발급 API에서 welcome badge를 response로 내려줌
- 마이페이지 조회시에 최근 badge를 response로 내려줌. 단일 객체이므로, 기존 badges에서 badge로 컬럼명 변경

<img width="612" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/81692211/5710fdab-c5ed-4f83-bfad-7aef58159c57">


<img width="553" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/81692211/a2f2db64-c341-41f4-a122-d46a3565c165">

