### PR TITLE
[REFACTOR] day가 ""로 들어올 경우 학습계획 설정 API 로직 수정

### DIFF
--- a/src/main/java/com/smeme/server/controller/MemberController.java
+++ b/src/main/java/com/smeme/server/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.smeme.server.dto.member.MemberUpdateRequestDTO;
 import com.smeme.server.service.MemberService;
 import com.smeme.server.util.ApiResponse;
 import com.smeme.server.util.Util;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -34,7 +35,7 @@ public class MemberController {
     }
 
     @PatchMapping("/plan")
-    public ResponseEntity<ApiResponse> updateUserPlan(Principal principal, @RequestBody MemberPlanUpdateRequestDTO requestDTO) {
+    public ResponseEntity<ApiResponse> updateUserPlan(Principal principal, @Valid @RequestBody MemberPlanUpdateRequestDTO requestDTO) {
         memberService.updateMemberPlan(Util.getMemberId(principal), requestDTO);
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USER_PLAN.getMessage()));
     }

--- a/src/main/java/com/smeme/server/dto/training/TrainingTimeRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/training/TrainingTimeRequestDTO.java
@@ -7,8 +7,10 @@ public record TrainingTimeRequestDTO(
         @NotNull
         String day,
 
+        @NotNull
         int hour,
 
+        @NotNull
         int minute
 ) {
 }

--- a/src/main/java/com/smeme/server/dto/training/TrainingTimeRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/training/TrainingTimeRequestDTO.java
@@ -1,8 +1,14 @@
 package com.smeme.server.dto.training;
 
+import jakarta.validation.constraints.NotNull;
+
 public record TrainingTimeRequestDTO(
+
+        @NotNull
         String day,
+
         int hour,
+
         int minute
 ) {
 }

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -24,7 +24,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -68,11 +67,9 @@ public class MemberService {
         Member member = getMemberById(memberId);
 
         if (!Objects.isNull(requestDTO.target())) member.updateGoal(requestDTO.target());
-
-        if (!Objects.isNull(requestDTO.trainingTime())) {
-            member.updateHasAlarm(requestDTO.hasAlarm());
-            updateMemberTrainingTime(member, requestDTO);
-        }
+        member.updateHasAlarm(requestDTO.hasAlarm());
+        trainingTimeRepository.deleteAll(member.getTrainingTimes());
+        if (!requestDTO.trainingTime().day().equals("")) updateMemberTrainingTime(member, requestDTO);
     }
 
     public MemberNameResponseDTO checkDuplicatedName(String name) {

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -69,7 +69,7 @@ public class MemberService {
         if (!Objects.isNull(requestDTO.target())) member.updateGoal(requestDTO.target());
         member.updateHasAlarm(requestDTO.hasAlarm());
         trainingTimeRepository.deleteAll(member.getTrainingTimes());
-        if (!requestDTO.trainingTime().day().equals("")) updateMemberTrainingTime(member, requestDTO);
+        if (!requestDTO.trainingTime().day().equals("")) { updateMemberTrainingTime(member, requestDTO);}
     }
 
     public MemberNameResponseDTO checkDuplicatedName(String name) {


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #123 

## Work Description 💚
- 현재 학습 계획 설정 API에서 day가 ""로 들어올 경우, 500 error를 뱉는다.
- > day가 ""로 들어오는 경우에도 요청은 200으로 이루어 지도록 API 로직 수정
<img width="868" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/81692211/55a03072-9146-4cf8-b4b5-92b96b726347">
