### PR TITLE
[REFACTOR] 학습 목표 타입만 request body에 들어오는 경우 처리

### DIFF
--- a/src/main/java/com/smeme/server/dto/member/MemberPlanUpdateRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberPlanUpdateRequestDTO.java
@@ -4,14 +4,16 @@ import com.smeme.server.dto.training.TrainingTimeRequestDTO;
 import com.smeme.server.model.goal.GoalType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+
+@Schema(description = "사용자 학습 계획 수정 요청")
 public record MemberPlanUpdateRequestDTO(
-        @Schema(description = "목표 타입", example = "HOBBY")
+        @Schema(description = "목표 Enum DEVELOP, HOBBY, APPLY, BUSINESS, EXAM, NONE", example = "HOBBY")
         GoalType target,
 
         @Schema(description = "학습 시간")
         TrainingTimeRequestDTO trainingTime,
 
         @Schema(description = "알람 여부", example = "true")
-        boolean hasAlarm
+        Boolean hasAlarm
 ) {
 }

--- a/src/main/java/com/smeme/server/dto/member/MemberPlanUpdateRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberPlanUpdateRequestDTO.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "사용자 학습 계획 수정 요청")
 public record MemberPlanUpdateRequestDTO(
-        @Schema(description = "목표 Enum DEVELOP, HOBBY, APPLY, BUSINESS, EXAM, NONE", example = "HOBBY")
+        @Schema(description = "목표 타입", example = "HOBBY")
         GoalType target,
 
         @Schema(description = "학습 시간")

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.nonNull;
+
 
 @Service
 @Transactional(readOnly = true)
@@ -77,10 +79,17 @@ public class MemberService {
     public void updateMemberPlan(Long memberId, MemberPlanUpdateRequestDTO requestDTO) {
         Member member = getMemberById(memberId);
 
-        if (!Objects.isNull(requestDTO.target())) member.updateGoal(requestDTO.target());
-        member.updateHasAlarm(requestDTO.hasAlarm());
-        trainingTimeRepository.deleteAll(member.getTrainingTimes());
-        if (!requestDTO.trainingTime().day().equals("")) { updateMemberTrainingTime(member, requestDTO);}
+        if (nonNull(requestDTO.target())) {
+            member.updateGoal(requestDTO.target());
+        }
+
+        if (nonNull(requestDTO.hasAlarm())) {
+            member.updateHasAlarm(requestDTO.hasAlarm());
+        }
+
+        if (nonNull(requestDTO.trainingTime()) && (!"".equals(requestDTO.trainingTime().day()))) {
+                updateMemberTrainingTime(member, requestDTO);
+        }
     }
 
     public MemberNameResponseDTO checkDuplicatedName(String name) {

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -23,6 +23,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -87,8 +88,8 @@ public class MemberService {
             member.updateHasAlarm(requestDTO.hasAlarm());
         }
 
-        if (nonNull(requestDTO.trainingTime()) && (!"".equals(requestDTO.trainingTime().day()))) {
-                updateMemberTrainingTime(member, requestDTO);
+        if (nonNull(requestDTO.trainingTime()) && StringUtils.hasText(requestDTO.trainingTime().day())) {
+            updateMemberTrainingTime(member, requestDTO);
         }
     }
 


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #132 

## Work Description 💚
- 학습 목표 타입만 request body에 들어오는 경우에도, 학습 목표가 업데이트 되도록 로직 수정
<img width="831" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/81692211/e044fa17-0d0b-4462-9ce3-076c055e2d48">
