### PR TITLE
[DOCS] Swagger에 Authorization Header 추가 가능하도록 수정

### DIFF
--- a/src/main/java/com/smeme/server/config/SwaggerConfig.java
+++ b/src/main/java/com/smeme/server/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.smeme.server.config;
+
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@SecurityScheme(
+        name = "Authorization",
+        in = SecuritySchemeIn.HEADER,
+        type = SecuritySchemeType.HTTP,
+        bearerFormat = "JWT",
+        scheme = "bearer",
+        description = "Authorization: Bearer ~"
+)
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Smeme Server API V2 Spec")
+                .description("Smeme API V2 Document")
+                .version("1.0.0");
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+}

--- a/src/main/java/com/smeme/server/controller/AuthController.java
+++ b/src/main/java/com/smeme/server/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.smeme.server.util.ApiResponse;
 import com.smeme.server.util.Util;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -53,6 +54,7 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_ISSUE_TOKEN.getMessage(),response));
     }
 
+    @SecurityRequirement(name = "Authorization")
     @Operation(summary = "로그아웃", description = "로그아웃 합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공",

--- a/src/main/java/com/smeme/server/controller/BadgeController.java
+++ b/src/main/java/com/smeme/server/controller/BadgeController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,7 @@ import static com.smeme.server.util.message.ResponseMessage.SUCCESS_GET_BADGES;
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/members/badges")
 @Tag(name = "Badge", description = "뱃지 관련 API")
+@SecurityRequirement(name = "Authorization")
 public class BadgeController {
 
     private final BadgeService badgeService;

--- a/src/main/java/com/smeme/server/controller/CorrectionController.java
+++ b/src/main/java/com/smeme/server/controller/CorrectionController.java
@@ -4,6 +4,7 @@ import static com.smeme.server.util.message.ResponseMessage.*;
 
 import java.security.Principal;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -32,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/corrections")
+@SecurityRequirement(name = "Authorization")
 public class CorrectionController {
 
 	private final CorrectionService correctionService;

--- a/src/main/java/com/smeme/server/controller/DiaryController.java
+++ b/src/main/java/com/smeme/server/controller/DiaryController.java
@@ -4,6 +4,7 @@ import static com.smeme.server.util.message.ResponseMessage.*;
 
 import java.security.Principal;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,13 +30,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Null;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Diary", description = "일기 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/diaries")
+@SecurityRequirement(name = "Authorization")
 public class DiaryController {
 
 	private final DiaryService diaryService;

--- a/src/main/java/com/smeme/server/controller/MemberController.java
+++ b/src/main/java/com/smeme/server/controller/MemberController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ import static com.smeme.server.util.message.ResponseMessage.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/members")
 @Tag(name = "Member", description = "사용자 관련 API")
+@SecurityRequirement(name = "Authorization")
 public class MemberController {
 
     private final MemberService memberService;

--- a/src/main/java/com/smeme/server/controller/TopicController.java
+++ b/src/main/java/com/smeme/server/controller/TopicController.java
@@ -2,6 +2,7 @@ package com.smeme.server.controller;
 
 import static com.smeme.server.util.message.ResponseMessage.*;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/topics")
+@SecurityRequirement(name = "Authorization")
 public class TopicController {
 
 	private final TopicService topicService;


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #138 

## Work Description 💚
- `SwaggerConfig` class에 `@SecurityScheme`을 추가했습니다.
- Token 검증이 필요 없는 API를 제외하고, `@SecurityRequirement` 어노테이션을 추가했습니다.