### PR TITLE
[REFACTOR] 소셜로그인, 회원정보 업데이트 API 수정

### DIFF
--- a/src/main/java/com/smeme/server/controller/MemberController.java
+++ b/src/main/java/com/smeme/server/controller/MemberController.java
@@ -1,10 +1,7 @@
 package com.smeme.server.controller;
 
 import com.smeme.server.dto.badge.BadgeListResponseDTO;
-import com.smeme.server.dto.member.MemberGetResponseDTO;
-import com.smeme.server.dto.member.MemberNameResponseDTO;
-import com.smeme.server.dto.member.MemberPlanUpdateRequestDTO;
-import com.smeme.server.dto.member.MemberUpdateRequestDTO;
+import com.smeme.server.dto.member.*;
 import com.smeme.server.service.MemberService;
 import com.smeme.server.util.ApiResponse;
 import com.smeme.server.util.Util;
@@ -37,7 +34,8 @@ public class MemberController {
     @PatchMapping()
     public ResponseEntity<ApiResponse> updateUserProfile(
             Principal principal, @RequestBody MemberUpdateRequestDTO requestDTO) {
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USERNAME.getMessage(), memberService.updateMember(Util.getMemberId(principal), requestDTO)));
+        MemberUpdateResponseDTO response = memberService.updateMember(Util.getMemberId(principal), requestDTO);
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USERNAME.getMessage(), response));
     }
 
     @Operation(summary = "사용자 정보 조회", description = "사용자의 정보를 조회합니다.")

--- a/src/main/java/com/smeme/server/controller/MemberController.java
+++ b/src/main/java/com/smeme/server/controller/MemberController.java
@@ -37,8 +37,7 @@ public class MemberController {
     @PatchMapping()
     public ResponseEntity<ApiResponse> updateUserProfile(
             Principal principal, @RequestBody MemberUpdateRequestDTO requestDTO) {
-        memberService.updateMember(Util.getMemberId(principal), requestDTO);
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USERNAME.getMessage()));
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USERNAME.getMessage(), memberService.updateMember(Util.getMemberId(principal), requestDTO)));
     }
 
     @Operation(summary = "사용자 정보 조회", description = "사용자의 정보를 조회합니다.")

--- a/src/main/java/com/smeme/server/dto/auth/SignInResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/auth/SignInResponseDTO.java
@@ -17,9 +17,6 @@ public record SignInResponseDTO(
         @Schema(description = "회원 등록 여부", example = "true")
         boolean isRegistered,
 
-        @Schema(description = "학습 계획 설정 여부", example = "false")
-        boolean hasPlan,
-
         List<BadgeResponseDTO> badges
 ) {
 

--- a/src/main/java/com/smeme/server/dto/badge/BadgeListResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/badge/BadgeListResponseDTO.java
@@ -7,4 +7,5 @@ public record BadgeListResponseDTO(List<BadgeResponseDTO> badges) {
     public static BadgeListResponseDTO of(List<BadgeResponseDTO> badges) {
         return new BadgeListResponseDTO(badges);
     }
+
 }

--- a/src/main/java/com/smeme/server/dto/member/MemberUpdateRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberUpdateRequestDTO.java
@@ -8,6 +8,6 @@ public record MemberUpdateRequestDTO(
         String username,
 
         @Schema(description = "정책 동의 여부", example = "false")
-        boolean termAccepted
+        Boolean termAccepted
 ) {
 }

--- a/src/main/java/com/smeme/server/dto/member/MemberUpdateResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberUpdateResponseDTO.java
@@ -1,0 +1,26 @@
+package com.smeme.server.dto.member;
+
+import com.smeme.server.model.badge.MemberBadge;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record MemberUpdateResponseDTO(
+        List<BadgeDTO> badges
+) {
+    public static MemberUpdateResponseDTO of(List<MemberBadge> badges) {
+        return new MemberUpdateResponseDTO(badges.stream().map(badge -> new BadgeDTO(badge.getBadge().getName(), badge.getBadge().getImageUrl())).toList());
+    }
+
+    record BadgeDTO(
+            @Schema(description = "뱃지 이름", example = "웰컴뱃지")
+            String name,
+
+            @Schema(description = "뱃지 이미지 url", example = "https://m.s3.ap-northeast-2.amazonaws.com/badge/welcome.png")
+            String imageUrl
+    ) {
+
+    }
+
+}
+

--- a/src/main/java/com/smeme/server/dto/member/MemberUpdateResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberUpdateResponseDTO.java
@@ -1,5 +1,6 @@
 package com.smeme.server.dto.member;
 
+import com.smeme.server.model.badge.Badge;
 import com.smeme.server.model.badge.MemberBadge;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -8,8 +9,8 @@ import java.util.List;
 public record MemberUpdateResponseDTO(
         List<BadgeDTO> badges
 ) {
-    public static MemberUpdateResponseDTO of(List<MemberBadge> badges) {
-        return new MemberUpdateResponseDTO(badges.stream().map(badge -> new BadgeDTO(badge.getBadge().getName(), badge.getBadge().getImageUrl())).toList());
+    public static MemberUpdateResponseDTO of(List<Badge> badges) {
+        return new MemberUpdateResponseDTO(badges.stream().map(badge -> new BadgeDTO(badge.getName(), badge.getImageUrl())).toList());
     }
 
     record BadgeDTO(

--- a/src/main/java/com/smeme/server/model/badge/MemberBadge.java
+++ b/src/main/java/com/smeme/server/model/badge/MemberBadge.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -55,14 +55,14 @@ public class MemberService {
             member.updateTermAccepted(dto.termAccepted());
         }
 
+        ArrayList<Badge> badges = new ArrayList<>();
         if (isNull(member.getUsername())) {
-            member.updateUsername(dto.username());
-            memberBadgeRepository.saveAndFlush(new MemberBadge(member, getBadgeById(WELCOME_BADGE_ID)));
-            return MemberUpdateResponseDTO.of(member.getBadges());
+            Badge welcomeBadge = getBadgeById(WELCOME_BADGE_ID);
+            memberBadgeRepository.save(new MemberBadge(member, welcomeBadge));
+            badges.add(welcomeBadge);
         }
         member.updateUsername(dto.username());
-        List<MemberBadge> memberBadges = new ArrayList<>();
-        return MemberUpdateResponseDTO.of(memberBadges);
+        return MemberUpdateResponseDTO.of(badges);
     }
 
     public MemberGetResponseDTO getMember(Long memberId) {

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -1,13 +1,11 @@
 package com.smeme.server.service;
 
 import com.smeme.server.dto.badge.BadgeResponseDTO;
-import com.smeme.server.dto.member.MemberGetResponseDTO;
-import com.smeme.server.dto.member.MemberNameResponseDTO;
-import com.smeme.server.dto.member.MemberPlanUpdateRequestDTO;
-import com.smeme.server.dto.member.MemberUpdateRequestDTO;
+import com.smeme.server.dto.member.*;
 import com.smeme.server.dto.training.TrainingTimeResponseDTO;
 import com.smeme.server.model.Member;
 import com.smeme.server.model.badge.Badge;
+import com.smeme.server.model.badge.MemberBadge;
 import com.smeme.server.model.goal.Goal;
 import com.smeme.server.model.goal.GoalType;
 import com.smeme.server.model.training.DayType;
@@ -21,14 +19,16 @@ import com.smeme.server.util.message.ErrorMessage;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 
@@ -37,6 +37,9 @@ import static java.util.Objects.nonNull;
 @RequiredArgsConstructor
 public class MemberService {
 
+    @Value("${badge.welcome-badge-id}")
+    private Long WELCOME_BADGE_ID;
+
     private final MemberRepository memberRepository;
     private final TrainingTimeRepository trainingTimeRepository;
     private final MemberBadgeRepository memberBadgeRepository;
@@ -44,11 +47,22 @@ public class MemberService {
     private final BadgeRepository badgeRepository;
 
     @Transactional
-    public void updateMember(Long memberId, MemberUpdateRequestDTO dto) {
+    public MemberUpdateResponseDTO updateMember(Long memberId, MemberUpdateRequestDTO dto) {
         checkMemberDuplicate(dto.username());
         Member member = getMemberById(memberId);
+
+        if (nonNull(dto.termAccepted())) {
+            member.updateTermAccepted(dto.termAccepted());
+        }
+
+        if (isNull(member.getUsername())) {
+            member.updateUsername(dto.username());
+            memberBadgeRepository.saveAndFlush(new MemberBadge(member, getBadgeById(WELCOME_BADGE_ID)));
+            return MemberUpdateResponseDTO.of(member.getBadges());
+        }
         member.updateUsername(dto.username());
-        member.updateTermAccepted(dto.termAccepted());
+        List<MemberBadge> memberBadges = new ArrayList<>();
+        return MemberUpdateResponseDTO.of(memberBadges);
     }
 
     public MemberGetResponseDTO getMember(Long memberId) {
@@ -150,5 +164,11 @@ public class MemberService {
         if (memberRepository.existsByUsername(username)) {
             throw new EntityExistsException(ErrorMessage.DUPLICATE_USERNAME.getMessage());
         }
+    }
+
+    private Badge getBadgeById(Long id) {
+        return badgeRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException(ErrorMessage.EMPTY_BADGE.getMessage())
+        );
     }
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #137 

## Work Description 💚
- 소셜로그인시에, member의 username 값이 null인지 아닌지 여부로 회원정보 입력 여부를 판단했습니다.
```
boolean isRegistered = false;
        Member signedMember = getMemberBySocialAndSocialId(socialType, socialId);
        if (nonNull(signedMember.getUsername())) {
            isRegistered = true;
        }
```
- 회원 정보 업데이트시에, `username`이 있는지 여부로 웰컴 뱃지 response 여부를 결정합니다.
- `MemberBadgeRepository`에 save method로 `MemberBadge`를 저장하고 조회 했을 때  DB에는 member_badge row가 한 개 저장되는데, 
 `return MemberUpdateResponseDTO.of(member.getBadges());`로  API response를 확인하면 웰컴 뱃지가 2개 있는 것으로 나오네요. 영속성 컨텍스트 상에 MemberBadge entity가 2개 있어서 그런 것 같은데... 이유는 확실하지 않아서, save에서 saveAndFlush로 우선 구현했는데, 이 부분 review 부탁드립니다.

<img width="855" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/81692211/2709f510-6daf-486a-a512-4f8ec53281d0">

<img width="795" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/81692211/1aaec252-42b0-467a-a7e8-ee33bec7a6cf">


