### PR TITLE
[CHORE] 컨벤션 통일

### DIFF
--- a/src/main/java/com/smeme/server/config/JpaQueryFactoryConfig.java
+++ b/src/main/java/com/smeme/server/config/JpaQueryFactoryConfig.java
@@ -10,8 +10,8 @@ import jakarta.persistence.EntityManager;
 @Configuration
 public class JpaQueryFactoryConfig {
 
-	@Bean
-	JPAQueryFactory jpaQueryFactory(EntityManager em) {
-		return new JPAQueryFactory(em);
-	}
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
 }

--- a/src/main/java/com/smeme/server/config/SecurityConfig.java
+++ b/src/main/java/com/smeme/server/config/SecurityConfig.java
@@ -21,16 +21,10 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
 
-    private static final String[] AUTH_WHITELIST_DEV = {
+    private static final String[] AUTH_WHITELIST = {
             "/api/v2/auth",
             "/api/v2/test",
             "/api/beta/token",
-            "/v3/api-docs/**",
-            "/swagger-ui/**",
-            "/swagger-ui.html",
-            "/swagger-ui/index.html",
-            "/docs/swagger-ui/index.html",
-            "/swagger-ui/swagger-ui.css",
             "/error",
             "/favicon.ico",
             "/api/v2/members/nickname/check",
@@ -38,15 +32,13 @@ public class SecurityConfig {
             "/api/v2/goals/{type}"
     };
 
-    private static final String[] AUTH_WHITELIST_PROD = {
-            "/api/v2/auth",
-            "/api/v2/test",
-            "/api/beta/token",
-            "/error",
-            "/favicon.ico",
-            "/api/v2/members/nickname/check",
-            "/api/v2/goals",
-            "/api/v2/goals/{type}"
+    private static final String[] AUTH_WHITELIST_SWAGGER = {
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/swagger-ui/index.html",
+            "/docs/swagger-ui/index.html",
+            "/swagger-ui/swagger-ui.css"
     };
 
     @Bean
@@ -62,7 +54,8 @@ public class SecurityConfig {
                 .authenticationEntryPoint(customJwtAuthenticationEntryPoint)
                 .and()
                 .authorizeHttpRequests()
-                .requestMatchers(AUTH_WHITELIST_DEV).permitAll()
+                .requestMatchers(AUTH_WHITELIST).permitAll()
+                .requestMatchers(AUTH_WHITELIST_SWAGGER).permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
@@ -82,7 +75,7 @@ public class SecurityConfig {
                 .authenticationEntryPoint(customJwtAuthenticationEntryPoint)
                 .and()
                 .authorizeHttpRequests()
-                .requestMatchers(AUTH_WHITELIST_PROD).permitAll()
+                .requestMatchers(AUTH_WHITELIST).permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/smeme/server/config/TimezoneConfig.java
+++ b/src/main/java/com/smeme/server/config/TimezoneConfig.java
@@ -9,8 +9,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class TimezoneConfig {
 
-	@PostConstruct
-	public void init() {
-		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-	}
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 }

--- a/src/main/java/com/smeme/server/config/ValueConfig.java
+++ b/src/main/java/com/smeme/server/config/ValueConfig.java
@@ -1,0 +1,46 @@
+package com.smeme.server.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Getter
+@Configuration
+public class ValueConfig {
+
+    @Value("${jwt.secret}")
+    private String JWT_SECRET;
+
+    @Value("${fcm.smeem_title}")
+    private String MESSAGE_TITLE;
+
+    @Value("${fcm.smeem_body}")
+    private String MESSAGE_BODY;
+
+    @Value("${jwt.APPLE_URL}")
+    private String APPLE_URL;
+
+    @Value("${badge.welcome-badge-id}")
+    private Long WELCOME_BADGE_ID;
+
+    @Value("${jwt.KAKAO_URL}")
+    private String KAKAO_URL;
+
+    @Value("${fcm.file_path}")
+    private String FIREBASE_CONFIG_PATH;
+
+    @Value("${fcm.url}")
+    private String FIREBASE_API_URI;
+
+    @Value("${fcm.google_api}")
+    private String GOOGLE_API_URI;
+
+    @PostConstruct
+    protected void init() {
+        JWT_SECRET = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/smeme/server/config/jwt/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/smeme/server/config/jwt/CustomJwtAuthenticationEntryPoint.java
@@ -1,30 +1,33 @@
 package com.smeme.server.config.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.smeme.server.util.ApiResponse;
-import com.smeme.server.util.message.ErrorMessage;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+import static com.smeme.server.util.ApiResponse.fail;
+import static com.smeme.server.util.message.ErrorMessage.INVALID_TOKEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 @Component
 public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
-      setResponse(response);
+        setResponse(response);
     }
 
     private void setResponse(HttpServletResponse response) throws IOException {
         response.setCharacterEncoding("UTF-8");
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter().println(objectMapper.writeValueAsString(ApiResponse.fail(ErrorMessage.INVALID_TOKEN.getMessage())));
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setStatus(SC_UNAUTHORIZED);
+        response.getWriter().println(objectMapper.writeValueAsString(fail(INVALID_TOKEN.getMessage())));
     }
 }

--- a/src/main/java/com/smeme/server/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/smeme/server/config/jwt/JwtAuthenticationFilter.java
@@ -11,12 +11,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
 import static com.smeme.server.config.jwt.JwtValidationType.*;
+import static org.springframework.util.StringUtils.hasText;
 
 @Slf4j
 @Component
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             final String token = getJwtFromRequest(request);
 
-            if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token) == VALID_JWT) {
+            if (hasText(token) && jwtTokenProvider.validateToken(token) == VALID_JWT) {
                 Long userId = jwtTokenProvider.getUserFromJwt(token);
                 UserAuthentication authentication = new UserAuthentication(userId, null, null);
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
@@ -45,9 +45,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private String getJwtFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring("Bearer ".length());
-        }
-        return null;
+        return (hasText(bearerToken) && bearerToken.startsWith("Bearer ")) ? bearerToken.substring("Bearer ".length()) : null;
     }
 }

--- a/src/main/java/com/smeme/server/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/smeme/server/config/jwt/JwtTokenProvider.java
@@ -1,44 +1,39 @@
 package com.smeme.server.config.jwt;
 
 
+import com.smeme.server.config.ValueConfig;
 import io.jsonwebtoken.*;
-import io.jsonwebtoken.security.Keys;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import javax.crypto.SecretKey;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Date;
+
+import static com.smeme.server.config.jwt.JwtValidationType.*;
+import static io.jsonwebtoken.Header.*;
+import static io.jsonwebtoken.security.Keys.hmacShaKeyFor;
+import static java.util.Base64.getEncoder;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    @Value("${jwt.secret}")
-    private String JWT_SECRET;
-
-    @PostConstruct
-    protected void init() {
-        JWT_SECRET = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
-    }
+    private final ValueConfig valueConfig;
 
     public String generateToken(Authentication authentication, Long tokenExpirationTime) {
-        final Date now = new Date();
+        val now = new Date();
 
-        final Claims claims = Jwts.claims()
+        val claims = Jwts.claims()
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + tokenExpirationTime));
 
         claims.put("memberId", authentication.getPrincipal());
 
         return Jwts.builder()
-                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setHeaderParam(TYPE, JWT_TYPE)
                 .setClaims(claims)
                 .signWith(getSigningKey())
                 .compact();
@@ -46,26 +41,31 @@ public class JwtTokenProvider {
 
     public JwtValidationType validateToken(String token) {
         try {
-            final Claims claims = getBody(token);
-            return JwtValidationType.VALID_JWT;
+            getBody(token);
+            return VALID_JWT;
         } catch (MalformedJwtException ex) {
-            log.error(String.valueOf(JwtValidationType.INVALID_JWT_TOKEN));
-            return JwtValidationType.INVALID_JWT_TOKEN;
+            log.error(String.valueOf(INVALID_JWT_TOKEN));
+            return INVALID_JWT_TOKEN;
         } catch (ExpiredJwtException ex) {
-            log.error(String.valueOf(JwtValidationType.EXPIRED_JWT_TOKEN));
-            return JwtValidationType.EXPIRED_JWT_TOKEN;
+            log.error(String.valueOf(EXPIRED_JWT_TOKEN));
+            return EXPIRED_JWT_TOKEN;
         } catch (UnsupportedJwtException ex) {
-            log.error(String.valueOf(JwtValidationType.UNSUPPORTED_JWT_TOKEN));
-            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+            log.error(String.valueOf(UNSUPPORTED_JWT_TOKEN));
+            return UNSUPPORTED_JWT_TOKEN;
         } catch (IllegalArgumentException ex) {
-            log.error(String.valueOf(JwtValidationType.EMPTY_JWT));
-            return JwtValidationType.EMPTY_JWT;
+            log.error(String.valueOf(EMPTY_JWT));
+            return EMPTY_JWT;
         }
     }
 
+    public Long getUserFromJwt(String token) {
+        Claims claims = getBody(token);
+        return Long.parseLong(claims.get("memberId").toString());
+    }
+
     private SecretKey getSigningKey() {
-        String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes());
-        return Keys.hmacShaKeyFor(encodedKey.getBytes());
+        String encodedKey = getEncoder().encodeToString(valueConfig.getJWT_SECRET().getBytes());
+        return hmacShaKeyFor(encodedKey.getBytes());
     }
 
     private Claims getBody(final String token) {
@@ -74,10 +74,5 @@ public class JwtTokenProvider {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
-    }
-
-    public Long getUserFromJwt(String token) {
-        Claims claims = getBody(token);
-        return Long.parseLong(claims.get("memberId").toString());
     }
 }

--- a/src/main/java/com/smeme/server/controller/AuthController.java
+++ b/src/main/java/com/smeme/server/controller/AuthController.java
@@ -35,8 +35,8 @@ public class AuthController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공",
                     content = @io.swagger.v3.oas.annotations.media.Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = SignInResponseDTO.class)))})
     @PostMapping
-    public ResponseEntity<ApiResponse> signIn(@RequestHeader("Authorization") String socialAccessToken, @RequestBody SignInRequestDTO requestDTO) throws NoSuchAlgorithmException, InvalidKeySpecException {
-        SignInResponseDTO response = authService.signIn(socialAccessToken, requestDTO);
+    public ResponseEntity<ApiResponse> signIn(@RequestHeader("Authorization") String socialAccessToken, @RequestBody SignInRequestDTO request) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        SignInResponseDTO response = authService.signIn(socialAccessToken, request);
         return ResponseEntity.ok(success(SUCCESS_SIGNIN.getMessage(), response));
     }
 

--- a/src/main/java/com/smeme/server/controller/AuthController.java
+++ b/src/main/java/com/smeme/server/controller/AuthController.java
@@ -6,7 +6,6 @@ import com.smeme.server.dto.auth.SignInResponseDTO;
 import com.smeme.server.dto.auth.token.TokenResponseDTO;
 import com.smeme.server.service.auth.AuthService;
 import com.smeme.server.util.ApiResponse;
-import com.smeme.server.util.Util;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -19,6 +18,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.security.spec.InvalidKeySpecException;
 
+import static com.smeme.server.util.ApiResponse.success;
+import static com.smeme.server.util.Util.getMemberId;
 import static com.smeme.server.util.message.ResponseMessage.*;
 
 @RestController
@@ -33,13 +34,10 @@ public class AuthController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공",
                     content = @io.swagger.v3.oas.annotations.media.Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = SignInResponseDTO.class)))})
-    @PostMapping()
-    public ResponseEntity<ApiResponse> signIn(
-            @RequestHeader("Authorization") String socialAccessToken,
-            @RequestBody SignInRequestDTO requestDTO
-            ) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    @PostMapping
+    public ResponseEntity<ApiResponse> signIn(@RequestHeader("Authorization") String socialAccessToken, @RequestBody SignInRequestDTO requestDTO) throws NoSuchAlgorithmException, InvalidKeySpecException {
         SignInResponseDTO response = authService.signIn(socialAccessToken, requestDTO);
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_SIGNIN.getMessage(),response));
+        return ResponseEntity.ok(success(SUCCESS_SIGNIN.getMessage(), response));
     }
 
     @Operation(summary = "토큰 재발급", description = "토큰을 재발급 받습니다.")
@@ -47,11 +45,9 @@ public class AuthController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
                     content = @io.swagger.v3.oas.annotations.media.Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = TokenResponseDTO.class)))})
     @PostMapping("/token")
-    public ResponseEntity<ApiResponse> reissueToken(
-        Principal principal
-    ) {
-        TokenResponseDTO response = authService.issueToken(Util.getMemberId(principal));
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_ISSUE_TOKEN.getMessage(),response));
+    public ResponseEntity<ApiResponse> reissueToken(Principal principal) {
+        TokenResponseDTO response = authService.issueToken(getMemberId(principal));
+        return ResponseEntity.ok(success(SUCCESS_ISSUE_TOKEN.getMessage(), response));
     }
 
     @SecurityRequirement(name = "Authorization")
@@ -61,8 +57,8 @@ public class AuthController {
                     content = @io.swagger.v3.oas.annotations.media.Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ApiResponse.class)))})
     @PostMapping("/sign-out")
     public ResponseEntity<ApiResponse> signOut(Principal principal) {
-        authService.signOut(Util.getMemberId(principal));
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_SIGNOUT.getMessage()));
+        authService.signOut(getMemberId(principal));
+        return ResponseEntity.ok(success(SUCCESS_SIGNOUT.getMessage()));
     }
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 합니다.")
@@ -71,7 +67,7 @@ public class AuthController {
                     content = @io.swagger.v3.oas.annotations.media.Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ApiResponse.class)))})
     @DeleteMapping
     public ResponseEntity<ApiResponse> withDrawl(Principal principal) {
-        authService.withdraw(Util.getMemberId(principal));
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_WITHDRAW.getMessage()));
+        authService.withdraw(getMemberId(principal));
+        return ResponseEntity.ok(success(SUCCESS_WITHDRAW.getMessage()));
     }
 }

--- a/src/main/java/com/smeme/server/controller/BadgeController.java
+++ b/src/main/java/com/smeme/server/controller/BadgeController.java
@@ -3,7 +3,6 @@ package com.smeme.server.controller;
 import com.smeme.server.dto.badge.BadgeListResponseDTO;
 import com.smeme.server.service.BadgeService;
 import com.smeme.server.util.ApiResponse;
-import com.smeme.server.util.Util;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,6 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
 
+import static com.smeme.server.util.ApiResponse.success;
+import static com.smeme.server.util.Util.getMemberId;
 import static com.smeme.server.util.message.ResponseMessage.SUCCESS_GET_BADGES;
 
 @RestController
@@ -35,7 +36,8 @@ public class BadgeController {
                     content = @Content(schema = @Schema(implementation = BadgeListResponseDTO.class)))})
     @GetMapping
     public ResponseEntity<ApiResponse> getBadgeList(Principal principal) {
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_BADGES.getMessage(), badgeService.getBadgeList(Util.getMemberId(principal))));
+        BadgeListResponseDTO response = badgeService.getBadgeList(getMemberId(principal));
+        return ResponseEntity.ok(success(SUCCESS_GET_BADGES.getMessage(), response));
     }
 
 }

--- a/src/main/java/com/smeme/server/controller/BetaAuthController.java
+++ b/src/main/java/com/smeme/server/controller/BetaAuthController.java
@@ -32,8 +32,8 @@ public class BetaAuthController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "베타 테스트용 임시 토큰 발급 성공"
                     , content = @io.swagger.v3.oas.annotations.media.Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = BetaTokenResponseDTO.class)))})
     @PostMapping("/token")
-    public ResponseEntity<ApiResponse> getToken(@RequestBody BetaSignInRequestDTO requestDTO) {
-        BetaTokenResponseDTO response = betaAuthService.createBetaMember(requestDTO);
+    public ResponseEntity<ApiResponse> getToken(@RequestBody BetaSignInRequestDTO request) {
+        BetaTokenResponseDTO response = betaAuthService.createBetaMember(request);
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_BETA_AUTH_TOKEN.getMessage(), response));
     }
 }

--- a/src/main/java/com/smeme/server/controller/BetaAuthController.java
+++ b/src/main/java/com/smeme/server/controller/BetaAuthController.java
@@ -30,9 +30,10 @@ public class BetaAuthController {
     @Operation(summary = "베타 테스트용 임시 토큰 발급", description = "베타 테스트용 임시 토큰을 발급합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "베타 테스트용 임시 토큰 발급 성공"
-            ,content = @io.swagger.v3.oas.annotations.media.Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = BetaTokenResponseDTO.class)))})
+                    , content = @io.swagger.v3.oas.annotations.media.Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = BetaTokenResponseDTO.class)))})
     @PostMapping("/token")
-    public ResponseEntity<ApiResponse> getToken(@RequestBody BetaSignInRequestDTO betaSignInRequestDTO) {
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_BETA_AUTH_TOKEN.getMessage(), betaAuthService.createBetaMember(betaSignInRequestDTO)));
+    public ResponseEntity<ApiResponse> getToken(@RequestBody BetaSignInRequestDTO requestDTO) {
+        BetaTokenResponseDTO response = betaAuthService.createBetaMember(requestDTO);
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_BETA_AUTH_TOKEN.getMessage(), response));
     }
 }

--- a/src/main/java/com/smeme/server/controller/CorrectionController.java
+++ b/src/main/java/com/smeme/server/controller/CorrectionController.java
@@ -1,5 +1,8 @@
 package com.smeme.server.controller;
 
+import static com.smeme.server.util.ApiResponse.success;
+import static com.smeme.server.util.Util.getMemberId;
+import static com.smeme.server.util.Util.getURI;
 import static com.smeme.server.util.message.ResponseMessage.*;
 
 import java.security.Principal;
@@ -16,15 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.smeme.server.dto.correction.CorrectionRequestDTO;
 import com.smeme.server.dto.correction.CorrectionResponseDTO;
-import com.smeme.server.dto.diary.DiariesResponseDTO;
 import com.smeme.server.service.CorrectionService;
 import com.smeme.server.util.ApiResponse;
-import com.smeme.server.util.Util;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -36,53 +35,47 @@ import lombok.RequiredArgsConstructor;
 @SecurityRequirement(name = "Authorization")
 public class CorrectionController {
 
-	private final CorrectionService correctionService;
+    private final CorrectionService correctionService;
 
-	@Operation(summary = "일기 첨삭", description = "일기 첨삭을 생성합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "201",
-			description = "일기 첨삭 성공")
-	})
-	@PostMapping("/diary/{diaryId}")
-	public ResponseEntity<ApiResponse> createCorrection(
-		@Parameter(hidden = true) Principal principal,
-		@Parameter(description = "일기 id") @PathVariable Long diaryId,
-		@RequestBody CorrectionRequestDTO requestDTO
-	) {
-		Long memberId = Util.getMemberId(principal);
-		CorrectionResponseDTO response = correctionService.createCorrection(memberId, diaryId, requestDTO);
-		return ResponseEntity
-			.created(Util.getURI(diaryId))
-			.body(ApiResponse.success(SUCCESS_CREATE_CORRECTION.getMessage(), response));
-	}
+    @Operation(summary = "일기 첨삭", description = "일기 첨삭을 생성합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "일기 첨삭 성공")
+    })
+    @PostMapping("/diary/{diaryId}")
+    public ResponseEntity<ApiResponse> createCorrection(
+            @Parameter(hidden = true) Principal principal,
+            @Parameter(description = "일기 id") @PathVariable Long diaryId,
+            @RequestBody CorrectionRequestDTO requestDTO
+    ) {
+        CorrectionResponseDTO response = correctionService.createCorrection(getMemberId(principal), diaryId, requestDTO);
+        return ResponseEntity
+                .created(getURI(diaryId))
+                .body(success(SUCCESS_CREATE_CORRECTION.getMessage(), response));
+    }
 
-	@Operation(summary = "첨삭 삭제", description = "첨삭을 삭제합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "200",
-			description = "첨삭 삭제 성공")
-	})
-	@DeleteMapping("/{correctionId}")
-	public ResponseEntity<ApiResponse> deleteCorrection(
-		@Parameter(description = "첨삭 id") @PathVariable Long correctionId
-	) {
-		correctionService.deleteCorrection(correctionId);
-		return ResponseEntity.ok(ApiResponse.success(SUCCESS_DELETE_CORRECTION.getMessage()));
-	}
+    @Operation(summary = "첨삭 삭제", description = "첨삭을 삭제합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "첨삭 삭제 성공")
+    })
+    @DeleteMapping("/{correctionId}")
+    public ResponseEntity<ApiResponse> deleteCorrection(@Parameter(description = "첨삭 id") @PathVariable Long correctionId) {
+        correctionService.deleteCorrection(correctionId);
+        return ResponseEntity.ok(success(SUCCESS_DELETE_CORRECTION.getMessage()));
+    }
 
-	@Operation(summary = "첨삭 수정", description = "첨삭을 수정합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "200",
-			description = "첨삭 수정 성공")
-	})
-	@PatchMapping("/{correctionId}")
-	public ResponseEntity<ApiResponse> updateCorrection(
-		@Parameter(description = "첨삭 id") @PathVariable Long correctionId,
-		@RequestBody CorrectionRequestDTO requestDTO
-	) {
-		correctionService.updateCorrection(correctionId, requestDTO);
-		return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_CORRECTION.getMessage()));
-	}
+    @Operation(summary = "첨삭 수정", description = "첨삭을 수정합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "첨삭 수정 성공")
+    })
+    @PatchMapping("/{correctionId}")
+    public ResponseEntity<ApiResponse> updateCorrection(@Parameter(description = "첨삭 id") @PathVariable Long correctionId, @RequestBody CorrectionRequestDTO requestDTO) {
+        correctionService.updateCorrection(correctionId, requestDTO);
+        return ResponseEntity.ok(success(SUCCESS_UPDATE_CORRECTION.getMessage()));
+    }
 }

--- a/src/main/java/com/smeme/server/controller/CorrectionController.java
+++ b/src/main/java/com/smeme/server/controller/CorrectionController.java
@@ -47,9 +47,9 @@ public class CorrectionController {
     public ResponseEntity<ApiResponse> createCorrection(
             @Parameter(hidden = true) Principal principal,
             @Parameter(description = "일기 id") @PathVariable Long diaryId,
-            @RequestBody CorrectionRequestDTO requestDTO
+            @RequestBody CorrectionRequestDTO request
     ) {
-        CorrectionResponseDTO response = correctionService.createCorrection(getMemberId(principal), diaryId, requestDTO);
+        CorrectionResponseDTO response = correctionService.createCorrection(getMemberId(principal), diaryId, request);
         return ResponseEntity
                 .created(getURI(diaryId))
                 .body(success(SUCCESS_CREATE_CORRECTION.getMessage(), response));
@@ -74,8 +74,8 @@ public class CorrectionController {
                     description = "첨삭 수정 성공")
     })
     @PatchMapping("/{correctionId}")
-    public ResponseEntity<ApiResponse> updateCorrection(@Parameter(description = "첨삭 id") @PathVariable Long correctionId, @RequestBody CorrectionRequestDTO requestDTO) {
-        correctionService.updateCorrection(correctionId, requestDTO);
+    public ResponseEntity<ApiResponse> updateCorrection(@Parameter(description = "첨삭 id") @PathVariable Long correctionId, @RequestBody CorrectionRequestDTO request) {
+        correctionService.updateCorrection(correctionId, request);
         return ResponseEntity.ok(success(SUCCESS_UPDATE_CORRECTION.getMessage()));
     }
 }

--- a/src/main/java/com/smeme/server/controller/DiaryController.java
+++ b/src/main/java/com/smeme/server/controller/DiaryController.java
@@ -1,5 +1,8 @@
 package com.smeme.server.controller;
 
+import static com.smeme.server.util.ApiResponse.success;
+import static com.smeme.server.util.Util.getMemberId;
+import static com.smeme.server.util.Util.getURI;
 import static com.smeme.server.util.message.ResponseMessage.*;
 
 import java.security.Principal;
@@ -22,7 +25,6 @@ import com.smeme.server.dto.diary.DiaryRequestDTO;
 import com.smeme.server.dto.diary.DiaryResponseDTO;
 import com.smeme.server.service.DiaryService;
 import com.smeme.server.util.ApiResponse;
-import com.smeme.server.util.Util;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -39,78 +41,75 @@ import lombok.RequiredArgsConstructor;
 @SecurityRequirement(name = "Authorization")
 public class DiaryController {
 
-	private final DiaryService diaryService;
+    private final DiaryService diaryService;
 
-	@Operation(summary = "일기 생성", description = "일기를 생성합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "201",
-			description = "일기 생성 성공",
-			content = @Content(schema = @Schema(implementation = CreatedDiaryResponseDTO.class)))
-	})
-	@PostMapping
-	public ResponseEntity<ApiResponse> createDiary(
-		@Parameter(hidden = true) Principal principal, @RequestBody DiaryRequestDTO requestDTO
-	) {
-		Long memberId = Util.getMemberId(principal);
-		CreatedDiaryResponseDTO response = diaryService.createDiary(memberId, requestDTO);
-		return ResponseEntity
-			.created(Util.getURI(response.diaryId()))
-			.body(ApiResponse.success(SUCCESS_CREATE_DIARY.getMessage(), response));
-	}
+    @Operation(summary = "일기 생성", description = "일기를 생성합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "일기 생성 성공",
+                    content = @Content(schema = @Schema(implementation = CreatedDiaryResponseDTO.class)))
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse> createDiary(@Parameter(hidden = true) Principal principal, @RequestBody DiaryRequestDTO requestDTO) {
+        CreatedDiaryResponseDTO response = diaryService.createDiary(getMemberId(principal), requestDTO);
+        return ResponseEntity
+                .created(getURI(response.diaryId()))
+                .body(success(SUCCESS_CREATE_DIARY.getMessage(), response));
+    }
 
-	@Operation(summary = "일기 조회", description = "일기를 조회합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "200",
-			description = "일기 조회 성공",
-			content = @Content(schema = @Schema(implementation = DiaryResponseDTO.class)))
-	})
-	@GetMapping("/{diaryId}")
-	public ResponseEntity<ApiResponse> getDiaryDetail(@Parameter(name = "일기 id") @PathVariable Long diaryId) {
-		DiaryResponseDTO response = diaryService.getDiaryDetail(diaryId);
-		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_DIARY.getMessage(), response));
-	}
+    @Operation(summary = "일기 조회", description = "일기를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "일기 조회 성공",
+                    content = @Content(schema = @Schema(implementation = DiaryResponseDTO.class)))
+    })
+    @GetMapping("/{diaryId}")
+    public ResponseEntity<ApiResponse> getDiaryDetail(@Parameter(name = "일기 id") @PathVariable Long diaryId) {
+        DiaryResponseDTO response = diaryService.getDiaryDetail(diaryId);
+        return ResponseEntity.ok(success(SUCCESS_GET_DIARY.getMessage(), response));
+    }
 
-	@Operation(summary = "일기 수정", description = "일기를 수정합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "200",
-			description = "일기 수정 성공")
-	})
-	@PatchMapping("/{diaryId}")
-	public ResponseEntity<ApiResponse> updateDiary(
-		@Parameter(name = "일기 id") @PathVariable Long diaryId, @RequestBody DiaryRequestDTO requestDTO) {
-		diaryService.updateDiary(diaryId, requestDTO);
-		return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_DAIRY.getMessage()));
-	}
+    @Operation(summary = "일기 수정", description = "일기를 수정합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "일기 수정 성공")
+    })
+    @PatchMapping("/{diaryId}")
+    public ResponseEntity<ApiResponse> updateDiary(
+            @Parameter(name = "일기 id") @PathVariable Long diaryId, @RequestBody DiaryRequestDTO requestDTO) {
+        diaryService.updateDiary(diaryId, requestDTO);
+        return ResponseEntity.ok(success(SUCCESS_UPDATE_DAIRY.getMessage()));
+    }
 
-	@Operation(summary = "일기 삭제", description = "일기를 삭제합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "200",
-			description = "일기 삭제 성공")
-	})
-	@DeleteMapping("/{diaryId}")
-	public ResponseEntity<ApiResponse> deleteDiary(@Parameter(name = "일기 id") @PathVariable Long diaryId) {
-		diaryService.deleteDiary(diaryId);
-		return ResponseEntity.ok(ApiResponse.success(SUCCESS_DELETE_DIARY.getMessage()));
-	}
+    @Operation(summary = "일기 삭제", description = "일기를 삭제합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "일기 삭제 성공")
+    })
+    @DeleteMapping("/{diaryId}")
+    public ResponseEntity<ApiResponse> deleteDiary(@Parameter(name = "일기 id") @PathVariable Long diaryId) {
+        diaryService.deleteDiary(diaryId);
+        return ResponseEntity.ok(success(SUCCESS_DELETE_DIARY.getMessage()));
+    }
 
-	@Operation(summary = "일기 리스트 조회", description = "일기 리스트를 조회합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "200",
-			description = "일기 리스트 조회 성공",
-			content = @Content(schema = @Schema(implementation = DiariesResponseDTO.class)))
-	})
-	@GetMapping
-	public ResponseEntity<ApiResponse> getDiaries(
-		@Parameter(hidden = true) Principal principal,
-		@Parameter(name = "범위 시작 날짜(yyyy-MM-dd HH:mm)") @RequestParam(name = "start") String startDate,
-		@Parameter(name = "범위 끝 날짜(yyyy-MM-dd HH:mm)") @RequestParam(name = "end") String endDate
-	) {
-		DiariesResponseDTO response = diaryService.getDiaries(Util.getMemberId(principal), startDate, endDate);
-		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_DIARIES.getMessage(), response));
-	}
+    @Operation(summary = "일기 리스트 조회", description = "일기 리스트를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "일기 리스트 조회 성공",
+                    content = @Content(schema = @Schema(implementation = DiariesResponseDTO.class)))
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse> getDiaries(
+            @Parameter(hidden = true) Principal principal,
+            @Parameter(name = "범위 시작 날짜(yyyy-MM-dd HH:mm)") @RequestParam(name = "start") String startDate,
+            @Parameter(name = "범위 끝 날짜(yyyy-MM-dd HH:mm)") @RequestParam(name = "end") String endDate
+    ) {
+        DiariesResponseDTO response = diaryService.getDiaries(getMemberId(principal), startDate, endDate);
+        return ResponseEntity.ok(success(SUCCESS_GET_DIARIES.getMessage(), response));
+    }
 }

--- a/src/main/java/com/smeme/server/controller/DiaryController.java
+++ b/src/main/java/com/smeme/server/controller/DiaryController.java
@@ -51,8 +51,8 @@ public class DiaryController {
                     content = @Content(schema = @Schema(implementation = CreatedDiaryResponseDTO.class)))
     })
     @PostMapping
-    public ResponseEntity<ApiResponse> createDiary(@Parameter(hidden = true) Principal principal, @RequestBody DiaryRequestDTO requestDTO) {
-        CreatedDiaryResponseDTO response = diaryService.createDiary(getMemberId(principal), requestDTO);
+    public ResponseEntity<ApiResponse> createDiary(@Parameter(hidden = true) Principal principal, @RequestBody DiaryRequestDTO request) {
+        CreatedDiaryResponseDTO response = diaryService.createDiary(getMemberId(principal), request);
         return ResponseEntity
                 .created(getURI(response.diaryId()))
                 .body(success(SUCCESS_CREATE_DIARY.getMessage(), response));
@@ -79,8 +79,8 @@ public class DiaryController {
     })
     @PatchMapping("/{diaryId}")
     public ResponseEntity<ApiResponse> updateDiary(
-            @Parameter(name = "일기 id") @PathVariable Long diaryId, @RequestBody DiaryRequestDTO requestDTO) {
-        diaryService.updateDiary(diaryId, requestDTO);
+            @Parameter(name = "일기 id") @PathVariable Long diaryId, @RequestBody DiaryRequestDTO request) {
+        diaryService.updateDiary(diaryId, request);
         return ResponseEntity.ok(success(SUCCESS_UPDATE_DAIRY.getMessage()));
     }
 

--- a/src/main/java/com/smeme/server/controller/ErrorHandler.java
+++ b/src/main/java/com/smeme/server/controller/ErrorHandler.java
@@ -1,5 +1,6 @@
 package com.smeme.server.controller;
 
+import static com.smeme.server.util.ApiResponse.fail;
 import static org.springframework.http.HttpStatus.*;
 
 import java.io.IOException;
@@ -22,41 +23,41 @@ public class ErrorHandler {
 
 	@ExceptionHandler(EntityNotFoundException.class)
 	public ResponseEntity<ApiResponse> entityNotFoundException(EntityNotFoundException ex) {
-		return ResponseEntity.status(NOT_FOUND).body(ApiResponse.fail(ex.getMessage()));
+		return ResponseEntity.status(NOT_FOUND).body(fail(ex.getMessage()));
 	}
 
 	@ExceptionHandler(ChangeSetPersister.NotFoundException.class)
 	public ResponseEntity<ApiResponse> notFoundException(ChangeSetPersister.NotFoundException ex) {
-		return ResponseEntity.status(NOT_FOUND).body(ApiResponse.fail(ex.getMessage()));
+		return ResponseEntity.status(NOT_FOUND).body(fail(ex.getMessage()));
 	}
 
 	@ExceptionHandler(NoSuchElementException.class)
 	public ResponseEntity<ApiResponse> noSuchElementException(NoSuchElementException ex) {
-		return ResponseEntity.status(NOT_FOUND).body(ApiResponse.fail(ex.getMessage()));
+		return ResponseEntity.status(NOT_FOUND).body(fail(ex.getMessage()));
 	}
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ApiResponse> illegalArgumentException(IllegalArgumentException ex) {
-		return ResponseEntity.status(BAD_REQUEST).body(ApiResponse.fail(ex.getMessage()));
+		return ResponseEntity.status(BAD_REQUEST).body(fail(ex.getMessage()));
 	}
 
 	@ExceptionHandler(ConstraintViolationException.class)
 	public ResponseEntity<ApiResponse> constraintViolationException(ConstraintViolationException ex) {
-		return ResponseEntity.status(BAD_REQUEST).body(ApiResponse.fail(ex.getMessage()));
+		return ResponseEntity.status(BAD_REQUEST).body(fail(ex.getMessage()));
 	}
 
 	@ExceptionHandler(EntityExistsException.class)
 	public ResponseEntity<ApiResponse> entityExistsException(EntityExistsException ex) {
-		return ResponseEntity.status(BAD_REQUEST).body(ApiResponse.fail(ex.getMessage()));
+		return ResponseEntity.status(BAD_REQUEST).body(fail(ex.getMessage()));
 	}
 
 	@ExceptionHandler(InvalidBearerTokenException.class)
 	public ResponseEntity<ApiResponse> invalidBearerTokenException(InvalidBearerTokenException ex) {
-		return ResponseEntity.status(UNAUTHORIZED).body(ApiResponse.fail(ex.getMessage()));
+		return ResponseEntity.status(UNAUTHORIZED).body(fail(ex.getMessage()));
 	}
 
 	@ExceptionHandler(IOException.class)
 	public ResponseEntity<ApiResponse> ioException(IOException ex) {
-		return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(ApiResponse.fail(ex.getMessage()));
+		return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(fail(ex.getMessage()));
 	}
 }

--- a/src/main/java/com/smeme/server/controller/GoalController.java
+++ b/src/main/java/com/smeme/server/controller/GoalController.java
@@ -1,5 +1,6 @@
 package com.smeme.server.controller;
 
+import static com.smeme.server.util.ApiResponse.success;
 import static com.smeme.server.util.message.ResponseMessage.*;
 
 import org.springframework.http.ResponseEntity;
@@ -28,33 +29,31 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v2/goals")
 public class GoalController {
 
-	private final GoalService goalService;
+    private final GoalService goalService;
 
-	@Operation(summary = "모든 학습 목표 조회", description = "모든 학습 목표 리스트를 조회합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "200",
-			description = "학습 목표 리스트 조회 성공",
-			content = @Content(schema = @Schema(implementation = GoalsResponseDTO.class)))
-	})
-	@GetMapping
-	public ResponseEntity<ApiResponse> getAllGoals() {
-		GoalsResponseDTO response = goalService.getAllGoals();
-		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_GOALS.getMessage(), response));
-	}
+    @Operation(summary = "모든 학습 목표 조회", description = "모든 학습 목표 리스트를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "학습 목표 리스트 조회 성공",
+                    content = @Content(schema = @Schema(implementation = GoalsResponseDTO.class)))
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse> getAllGoals() {
+        GoalsResponseDTO response = goalService.getAllGoals();
+        return ResponseEntity.ok(success(SUCCESS_GET_GOALS.getMessage(), response));
+    }
 
-	@Operation(summary = "학습 목표 조회", description = "학습 목표 내용을 조회합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "200",
-			description = "학습 목표 조회 성공",
-			content = @Content(schema = @Schema(implementation = GoalResponseDTO.class)))
-	})
-	@GetMapping("/{type}")
-	public ResponseEntity<ApiResponse> getGoalByType(
-		@Parameter(description = "학습 목표 ENUM 값") @PathVariable GoalType type
-	) {
-		GoalResponseDTO response = goalService.getGoalByType(type);
-		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_GOAL.getMessage(), response));
-	}
+    @Operation(summary = "학습 목표 조회", description = "학습 목표 내용을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "학습 목표 조회 성공",
+                    content = @Content(schema = @Schema(implementation = GoalResponseDTO.class)))
+    })
+    @GetMapping("/{type}")
+    public ResponseEntity<ApiResponse> getGoalByType(@Parameter(description = "학습 목표 ENUM 값") @PathVariable GoalType type) {
+        GoalResponseDTO response = goalService.getGoalByType(type);
+        return ResponseEntity.ok(success(SUCCESS_GET_GOAL.getMessage(), response));
+    }
 }

--- a/src/main/java/com/smeme/server/controller/MemberController.java
+++ b/src/main/java/com/smeme/server/controller/MemberController.java
@@ -34,8 +34,8 @@ public class MemberController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용자 정보 수정 성공")})
     @PatchMapping()
-    public ResponseEntity<ApiResponse> updateUserProfile(Principal principal, @RequestBody MemberUpdateRequestDTO requestDTO) {
-        MemberUpdateResponseDTO response = memberService.updateMember(getMemberId(principal), requestDTO);
+    public ResponseEntity<ApiResponse> updateUserProfile(Principal principal, @RequestBody MemberUpdateRequestDTO request) {
+        MemberUpdateResponseDTO response = memberService.updateMember(getMemberId(principal), request);
         return ResponseEntity.ok(success(SUCCESS_UPDATE_USERNAME.getMessage(), response));
     }
 
@@ -53,8 +53,8 @@ public class MemberController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용자 학습 계획 성공")})
     @PatchMapping("/plan")
-    public ResponseEntity<ApiResponse> updateUserPlan(Principal principal, @Valid @RequestBody MemberPlanUpdateRequestDTO requestDTO) {
-        memberService.updateMemberPlan(getMemberId(principal), requestDTO);
+    public ResponseEntity<ApiResponse> updateUserPlan(Principal principal, @Valid @RequestBody MemberPlanUpdateRequestDTO request) {
+        memberService.updateMemberPlan(getMemberId(principal), request);
         return ResponseEntity.ok(success(SUCCESS_UPDATE_USER_PLAN.getMessage()));
     }
 
@@ -72,8 +72,8 @@ public class MemberController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용자 푸쉬 알람 동의 여부 수정 성공")})
     @PatchMapping("/push")
-    public ResponseEntity<ApiResponse> updateUserPush(Principal principal, @RequestBody MemberPushUpdateRequestDTO requestDTO) {
-        memberService.updateMemberPush(getMemberId(principal), requestDTO);
+    public ResponseEntity<ApiResponse> updateUserPush(Principal principal, @RequestBody MemberPushUpdateRequestDTO request) {
+        memberService.updateMemberPush(getMemberId(principal), request);
         return ResponseEntity.ok(success(SUCCESS_UPDATE_USER_PUSH.getMessage()));
     }
 

--- a/src/main/java/com/smeme/server/controller/MemberController.java
+++ b/src/main/java/com/smeme/server/controller/MemberController.java
@@ -1,10 +1,8 @@
 package com.smeme.server.controller;
 
-import com.smeme.server.dto.badge.BadgeListResponseDTO;
 import com.smeme.server.dto.member.*;
 import com.smeme.server.service.MemberService;
 import com.smeme.server.util.ApiResponse;
-import com.smeme.server.util.Util;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -19,6 +17,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
+import static com.smeme.server.util.ApiResponse.success;
+import static com.smeme.server.util.Util.getMemberId;
 import static com.smeme.server.util.message.ResponseMessage.*;
 
 @RestController
@@ -34,19 +34,19 @@ public class MemberController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용자 정보 수정 성공")})
     @PatchMapping()
-    public ResponseEntity<ApiResponse> updateUserProfile(
-            Principal principal, @RequestBody MemberUpdateRequestDTO requestDTO) {
-        MemberUpdateResponseDTO response = memberService.updateMember(Util.getMemberId(principal), requestDTO);
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USERNAME.getMessage(), response));
+    public ResponseEntity<ApiResponse> updateUserProfile(Principal principal, @RequestBody MemberUpdateRequestDTO requestDTO) {
+        MemberUpdateResponseDTO response = memberService.updateMember(getMemberId(principal), requestDTO);
+        return ResponseEntity.ok(success(SUCCESS_UPDATE_USERNAME.getMessage(), response));
     }
 
     @Operation(summary = "사용자 정보 조회", description = "사용자의 정보를 조회합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용자 정보 수정 성공"
-            ,content = @Content(schema = @Schema(implementation = MemberGetResponseDTO.class)))})
+                    , content = @Content(schema = @Schema(implementation = MemberGetResponseDTO.class)))})
     @GetMapping("/me")
     public ResponseEntity<ApiResponse> getUserProfile(Principal principal) {
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_USER.getMessage(),memberService.getMember(Util.getMemberId(principal))));
+        MemberGetResponseDTO response = memberService.getMember(getMemberId(principal));
+        return ResponseEntity.ok(success(SUCCESS_GET_USER.getMessage(), response));
     }
 
     @Operation(summary = "사용자 학습 계획 변경", description = "사용자의 학습 계획을 변경합니다.")
@@ -54,18 +54,18 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용자 학습 계획 성공")})
     @PatchMapping("/plan")
     public ResponseEntity<ApiResponse> updateUserPlan(Principal principal, @Valid @RequestBody MemberPlanUpdateRequestDTO requestDTO) {
-        memberService.updateMemberPlan(Util.getMemberId(principal), requestDTO);
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USER_PLAN.getMessage()));
+        memberService.updateMemberPlan(getMemberId(principal), requestDTO);
+        return ResponseEntity.ok(success(SUCCESS_UPDATE_USER_PLAN.getMessage()));
     }
 
     @Operation(summary = "닉네임 중복 체크", description = "닉네임 중복 체크를 합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "닉네임 중복 체크 성공"
-                    ,content = @Content(schema = @Schema(implementation = MemberNameResponseDTO.class)))})
+                    , content = @Content(schema = @Schema(implementation = MemberNameResponseDTO.class)))})
     @GetMapping("/nickname/check")
     public ResponseEntity<ApiResponse> checkDuplicatedName(@Parameter(description = "유저 닉네임") @RequestParam String name) {
         MemberNameResponseDTO response = memberService.checkDuplicatedName(name);
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_CHECK_DUPLICATED_NAME.getMessage(), response));
+        return ResponseEntity.ok(success(SUCCESS_CHECK_DUPLICATED_NAME.getMessage(), response));
     }
 
     @Operation(summary = "사용자 푸쉬 알람 동의 여부 수정", description = "사용자의 푸쉬 알람 동의 여부를 수정합니다.")
@@ -73,8 +73,8 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "사용자 푸쉬 알람 동의 여부 수정 성공")})
     @PatchMapping("/push")
     public ResponseEntity<ApiResponse> updateUserPush(Principal principal, @RequestBody MemberPushUpdateRequestDTO requestDTO) {
-        memberService.updateMemberPush(Util.getMemberId(principal), requestDTO);
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USER_PUSH.getMessage()));
+        memberService.updateMemberPush(getMemberId(principal), requestDTO);
+        return ResponseEntity.ok(success(SUCCESS_UPDATE_USER_PUSH.getMessage()));
     }
-    
+
 }

--- a/src/main/java/com/smeme/server/controller/ScheduleController.java
+++ b/src/main/java/com/smeme/server/controller/ScheduleController.java
@@ -2,7 +2,7 @@ package com.smeme.server.controller;
 
 import java.time.LocalDateTime;
 
-import org.springframework.beans.factory.annotation.Value;
+import com.smeme.server.config.ValueConfig;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,23 +17,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ScheduleController {
 
-	private final MessageService messageService;
-	private final DiaryService diaryService;
+    private final MessageService messageService;
+    private final DiaryService diaryService;
+    private final ValueConfig valueConfig;
 
-	@Value("${fcm.smeem_title}")
-	private String MESSAGE_TITLE;
-	@Value("${fcm.smeem_body}")
-	private String MESSAGE_BODY;
+    @Scheduled(cron = "0 0/30 * * * *")
+    public void pushMessage() throws InterruptedException {
+        Thread.sleep(1000);
+        messageService.pushMessageForTrainingTime(LocalDateTime.now(), valueConfig.getMESSAGE_TITLE(), valueConfig.getMESSAGE_BODY());
+    }
 
-	@Scheduled(cron = "0 0/30 * * * *")
-	public void pushMessage() throws InterruptedException {
-		Thread.sleep(1000);
-		messageService.pushMessageForTrainingTime(LocalDateTime.now(), MESSAGE_TITLE, MESSAGE_BODY);
-	}
-
-	@Scheduled(cron = "0 0 0 * * *")
-	public void deleteDiaries30Past() throws InterruptedException {
-		Thread.sleep(1000);
-		diaryService.deleteDiary30Past(LocalDateTime.now().minusDays(30));
-	}
+    @Scheduled(cron = "0 0 0 * * *")
+    public void deleteDiaries30Past() throws InterruptedException {
+        Thread.sleep(1000);
+        diaryService.deleteDiary30Past(LocalDateTime.now().minusDays(30));
+    }
 }

--- a/src/main/java/com/smeme/server/controller/TestController.java
+++ b/src/main/java/com/smeme/server/controller/TestController.java
@@ -4,7 +4,7 @@ import static com.smeme.server.util.ApiResponse.*;
 
 import java.security.Principal;
 
-import org.springframework.beans.factory.annotation.Value;
+import com.smeme.server.config.ValueConfig;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,29 +24,26 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/v2/test")
 public class TestController {
-	private final MessageService messageService;
 
-	@Value("${fcm.smeem_title}")
-	private String MESSAGE_TITLE;
-	@Value("${fcm.smeem_body}")
-	private String MESSAGE_BODY;
+    private final MessageService messageService;
+    private final ValueConfig valueConfig;
 
-	@Operation(summary = "서버 연결 테스트", description = "서버 연결을 테스트합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "서버 연결 성공")
-	})
-	@GetMapping
-	public ResponseEntity<ApiResponse> test() {
-		return ResponseEntity.ok(success("server connect"));
-	}
+    @Operation(summary = "서버 연결 테스트", description = "서버 연결을 테스트합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "서버 연결 성공")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse> test() {
+        return ResponseEntity.ok(success("server connect"));
+    }
 
-	@Operation(summary = "푸시 알림 테스트", description = "푸시 알림을 테스트합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 전송 성공")
-	})
-	@GetMapping("/alarm")
-	public ResponseEntity<ApiResponse> alarmTest(@Parameter(hidden = true) Principal principal) {
-		messageService.pushTest(MESSAGE_TITLE, MESSAGE_BODY, Long.valueOf(principal.getName()));
-		return ResponseEntity.ok(success("푸시 알림 전송 성공"));
-	}
+    @Operation(summary = "푸시 알림 테스트", description = "푸시 알림을 테스트합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 전송 성공")
+    })
+    @GetMapping("/alarm")
+    public ResponseEntity<ApiResponse> alarmTest(@Parameter(hidden = true) Principal principal) {
+        messageService.pushTest(valueConfig.getMESSAGE_TITLE(), valueConfig.getMESSAGE_BODY(), Long.valueOf(principal.getName()));
+        return ResponseEntity.ok(success("푸시 알림 전송 성공"));
+    }
 }

--- a/src/main/java/com/smeme/server/controller/TopicController.java
+++ b/src/main/java/com/smeme/server/controller/TopicController.java
@@ -1,5 +1,6 @@
 package com.smeme.server.controller;
 
+import static com.smeme.server.util.ApiResponse.success;
 import static com.smeme.server.util.message.ResponseMessage.*;
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -26,18 +27,18 @@ import lombok.RequiredArgsConstructor;
 @SecurityRequirement(name = "Authorization")
 public class TopicController {
 
-	private final TopicService topicService;
+    private final TopicService topicService;
 
-	@Operation(summary = "랜덤 주제 조회", description = "랜덤 주제를 임의로 조회합니다.")
-	@ApiResponses({
-		@io.swagger.v3.oas.annotations.responses.ApiResponse(
-			responseCode = "200",
-			description = "랜덤 주제 조회",
-			content = @Content(schema = @Schema(implementation = TopicResponseDTO.class)))
-	})
-	@GetMapping("/random")
-	public ResponseEntity<ApiResponse> getRandomTopic() {
-		TopicResponseDTO response = topicService.getRandomTopic();
-		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_RANDOM_TOPIC.getMessage(), response));
-	}
+    @Operation(summary = "랜덤 주제 조회", description = "랜덤 주제를 임의로 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "랜덤 주제 조회",
+                    content = @Content(schema = @Schema(implementation = TopicResponseDTO.class)))
+    })
+    @GetMapping("/random")
+    public ResponseEntity<ApiResponse> getRandomTopic() {
+        TopicResponseDTO response = topicService.getRandomTopic();
+        return ResponseEntity.ok(success(SUCCESS_GET_RANDOM_TOPIC.getMessage(), response));
+    }
 }

--- a/src/main/java/com/smeme/server/dto/auth/SignInRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/auth/SignInRequestDTO.java
@@ -6,12 +6,10 @@ import com.smeme.server.model.SocialType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SignInRequestDTO(
-        
         @Schema(description = "소셜 로그인 타입", example = "KAKAO")
         @JsonProperty("social")
         SocialType socialType,
-
         @Schema(description = "fcm 토큰", example = "dsdsdsdsds")
         String fcmToken
-        ) {
+) {
 }

--- a/src/main/java/com/smeme/server/dto/correction/CorrectionRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/correction/CorrectionRequestDTO.java
@@ -3,9 +3,10 @@ package com.smeme.server.dto.correction;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record CorrectionRequestDTO(
-	@Schema(description = "첨삭할 문장", example = "Hello")
-	String sentence,
+        @Schema(description = "첨삭할 문장", example = "Hello")
+        String sentence,
 
-	@Schema(description = "첨삭 내용", example = "Hi")
-	String content) {
+        @Schema(description = "첨삭 내용", example = "Hi")
+        String content
+) {
 }

--- a/src/main/java/com/smeme/server/dto/diary/CreatedDiaryResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/diary/CreatedDiaryResponseDTO.java
@@ -8,25 +8,25 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "일기 생성 응답 DTO")
 public record CreatedDiaryResponseDTO(
-	@Schema(description = "생성된 일기 id", example = "1")
-	Long diaryId,
-
-	@Schema(description = "획득한 뱃지 리스트")
-	List<BadgeDTO> badges
+        @Schema(description = "생성된 일기 id", example = "1")
+        Long diaryId,
+        @Schema(description = "획득한 뱃지 리스트")
+        List<BadgeDTO> badges
 ) {
-	public static CreatedDiaryResponseDTO of(Long diaryId, List<Badge> badges) {
-		return new CreatedDiaryResponseDTO(diaryId, badges.stream().map(BadgeDTO::of).toList());
-	}
+    public static CreatedDiaryResponseDTO of(Long diaryId, List<Badge> badges) {
+        return new CreatedDiaryResponseDTO(diaryId, badges.stream().map(BadgeDTO::of).toList());
+    }
+
+    record BadgeDTO(
+            @Schema(description = "뱃지 이름", example = "웰컴 뱃지")
+            String name,
+            @Schema(description = "뱃지 이미지 url", example = "image-url")
+            String imageUrl
+    ) {
+        public static BadgeDTO of(Badge badge) {
+            return new BadgeDTO(badge.getName(), badge.getImageUrl());
+        }
+    }
 }
 
-record BadgeDTO(
-	@Schema(description = "뱃지 이름", example = "웰컴 뱃지")
-	String name,
 
-	@Schema(description = "뱃지 이미지 url", example = "image-url")
-	String imageUrl
-) {
-	public static BadgeDTO of(Badge badge) {
-		return new BadgeDTO(badge.getName(), badge.getImageUrl());
-	}
-}

--- a/src/main/java/com/smeme/server/dto/diary/DiariesResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/diary/DiariesResponseDTO.java
@@ -3,38 +3,38 @@ package com.smeme.server.dto.diary;
 import java.util.List;
 
 import com.smeme.server.model.Diary;
-import com.smeme.server.util.Util;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import static com.smeme.server.util.Util.transferDateTimeToString;
+
 public record DiariesResponseDTO(
-	@Schema(description = "일기 정보 리스트")
-	List<DiaryDTO> diaries,
-
-	@Schema(description = "30일 전 일기 존재 여부", example = "true")
-	boolean has30Past
+        @Schema(description = "일기 정보 리스트")
+        List<DiaryDTO> diaries,
+        @Schema(description = "30일 전 일기 존재 여부", example = "true")
+        boolean has30Past
 ) {
-	public static DiariesResponseDTO of(List<Diary> diaries, boolean has30Past) {
-		return new DiariesResponseDTO(
-			diaries.stream().map(DiaryDTO::of).toList(),
-			has30Past
-		);
-	}
+    public static DiariesResponseDTO of(List<Diary> diaries, boolean has30Past) {
+        return new DiariesResponseDTO(
+                diaries.stream().map(DiaryDTO::of).toList(),
+                has30Past
+        );
+    }
+
+    record DiaryDTO(
+            @Schema(description = "일기 id", example = "1")
+            Long diaryId,
+            @Schema(description = "일기 내용", example = "Hello Smeem")
+            String content,
+            @Schema(description = "일기 작성 일자", example = "2023-08-01 14:00")
+            String createdAt
+    ) {
+        public static DiaryDTO of(Diary diary) {
+            return new DiaryDTO(diary.getId(),
+                    diary.getContent(),
+                    transferDateTimeToString(diary.getCreatedAt()));
+        }
+    }
 }
 
-record DiaryDTO(
-	@Schema(description = "일기 id", example = "1")
-	Long diaryId,
 
-	@Schema(description = "일기 내용", example = "Hello Smeem")
-	String content,
-
-	@Schema(description = "일기 작성 일자", example = "2023-08-01 14:00")
-	String createdAt
-) {
-	public static DiaryDTO of(Diary diary) {
-		return new DiaryDTO(diary.getId(),
-			diary.getContent(),
-			Util.transferDateTimeToString(diary.getCreatedAt()));
-	}
-}

--- a/src/main/java/com/smeme/server/dto/diary/DiaryRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/diary/DiaryRequestDTO.java
@@ -5,11 +5,10 @@ import lombok.NonNull;
 
 @Schema(description = "일기 생성 요청 DTO")
 public record DiaryRequestDTO(
-	@Schema(description = "일기 내용", example = "Hello Smeem")
-	@NonNull
-	String content,
-
-	@Schema(description = "일기 랜덤주제 id", example = "1")
-	Long topicId
+        @Schema(description = "일기 내용", example = "Hello Smeem")
+        @NonNull
+        String content,
+        @Schema(description = "일기 랜덤주제 id", example = "1")
+        Long topicId
 ) {
 }

--- a/src/main/java/com/smeme/server/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/diary/DiaryResponseDTO.java
@@ -17,59 +17,61 @@ import lombok.Builder;
 @Schema(description = "일기 조회 응답 DTO")
 @Builder(access = AccessLevel.PRIVATE)
 public record DiaryResponseDTO(
-	@Schema(description = "일기 id", example = "1")
-	Long diaryId,
+        @Schema(description = "일기 id", example = "1")
+        Long diaryId,
 
-	@Schema(description = "랜덤 주제", example = "가보고 싶은 해외 여행지가 있다면 소개해 주세요!")
-	String topic,
+        @Schema(description = "랜덤 주제", example = "가보고 싶은 해외 여행지가 있다면 소개해 주세요!")
+        String topic,
 
-	@Schema(description = "일기 내용", example = "Hello Smeem")
-	String content,
+        @Schema(description = "일기 내용", example = "Hello Smeem")
+        String content,
 
-	@Schema(description = "생성일자", example = "2023-08-01 14:00")
-	String createdAt,
+        @Schema(description = "생성일자", example = "2023-08-01 14:00")
+        String createdAt,
 
-	@Schema(description = "작성자 이름", example = "스미미")
-	String username,
+        @Schema(description = "작성자 이름", example = "스미미")
+        String username,
 
-	@Schema(description = "첨삭 리스트")
-	List<CorrectionDTO> corrections
+        @Schema(description = "첨삭 리스트")
+        List<CorrectionDTO> corrections
 ) {
-	public static DiaryResponseDTO of(Diary diary, List<Correction> corrections) {
-		return DiaryResponseDTO.builder()
-			.diaryId(diary.getId())
-			.topic(getTopic(diary.getTopic()))
-			.content(diary.getContent())
-			.createdAt(getCreatedAt(diary.getCreatedAt()))
-			.username(diary.getMember().getUsername())
-			.corrections(getCorrections(corrections))
-			.build();
-	}
+    public static DiaryResponseDTO of(Diary diary, List<Correction> corrections) {
+        return DiaryResponseDTO.builder()
+                .diaryId(diary.getId())
+                .topic(getTopic(diary.getTopic()))
+                .content(diary.getContent())
+                .createdAt(getCreatedAt(diary.getCreatedAt()))
+                .username(diary.getMember().getUsername())
+                .corrections(getCorrections(corrections))
+                .build();
+    }
 
-	private static String getTopic(Topic topic) {
-		return nonNull(topic) ? topic.getContent() : "";
-	}
+    private static String getTopic(Topic topic) {
+        return nonNull(topic) ? topic.getContent() : "";
+    }
 
-	private static String getCreatedAt(LocalDateTime createdAt) {
-		return createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
-	}
+    private static String getCreatedAt(LocalDateTime createdAt) {
+        return createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+    }
 
-	private static List<CorrectionDTO> getCorrections(List<Correction> corrections) {
-		return corrections.stream().map(CorrectionDTO::of).toList();
-	}
+    private static List<CorrectionDTO> getCorrections(List<Correction> corrections) {
+        return corrections.stream().map(CorrectionDTO::of).toList();
+    }
+
+    record CorrectionDTO(
+            @Schema(description = "첨삭 id", example = "1")
+            Long correctionId,
+
+            @Schema(description = "첨삭 전 내용", example = "Hello")
+            String before,
+
+            @Schema(description = "첨삭 후 내용", example = "Hi")
+            String after
+    ) {
+        static CorrectionDTO of(Correction correction) {
+            return new CorrectionDTO(correction.getId(), correction.getBeforeSentence(), correction.getAfterSentence());
+        }
+    }
+
 }
 
-record CorrectionDTO(
-	@Schema(description = "첨삭 id", example = "1")
-	Long correctionId,
-
-	@Schema(description = "첨삭 전 내용", example = "Hello")
-	String before,
-
-	@Schema(description = "첨삭 후 내용", example = "Hi")
-	String after
-) {
-	static CorrectionDTO of(Correction correction) {
-		return new CorrectionDTO(correction.getId(), correction.getBeforeSentence(), correction.getAfterSentence());
-	}
-}

--- a/src/main/java/com/smeme/server/dto/goal/GoalResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/goal/GoalResponseDTO.java
@@ -3,13 +3,11 @@ package com.smeme.server.dto.goal;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record GoalResponseDTO(
-	@Schema(description = "학습 목표 이름", example = "현지 언어 체득")
-	String name,
-
-	@Schema(description = "학습 목표 방식", example = "주 5회 이상 오늘 하루를 돌아보는 일기 작성하기")
-	String way,
-
-	@Schema(description = "학습 목표 내용", example = "사전 없이 일기 완성\nsmeem 연속 일기 배지 획득")
-	String detail
+        @Schema(description = "학습 목표 이름", example = "현지 언어 체득")
+        String name,
+        @Schema(description = "학습 목표 방식", example = "주 5회 이상 오늘 하루를 돌아보는 일기 작성하기")
+        String way,
+        @Schema(description = "학습 목표 내용", example = "사전 없이 일기 완성\nsmeem 연속 일기 배지 획득")
+        String detail
 ) {
 }

--- a/src/main/java/com/smeme/server/dto/goal/GoalsResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/goal/GoalsResponseDTO.java
@@ -7,22 +7,21 @@ import com.smeme.server.model.goal.GoalType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record GoalsResponseDTO(
-	@Schema(description = "학습 목표 리스트")
-	List<GoalResponseVO> goals
+        @Schema(description = "학습 목표 리스트")
+        List<GoalResponseVO> goals
 ) {
-	public static GoalsResponseDTO of(List<GoalType> goalTypes) {
-		return new GoalsResponseDTO(goalTypes.stream().map(GoalResponseVO::of).toList());
-	}
-}
+    public static GoalsResponseDTO of(List<GoalType> goalTypes) {
+        return new GoalsResponseDTO(goalTypes.stream().map(GoalResponseVO::of).toList());
+    }
 
-record GoalResponseVO(
-	@Schema(description = "학습 목표 ENUM 값", example = "APPLY")
-	String goalType,
-
-	@Schema(description = "학습 목표 이름", example = "현지 언어 체득")
-	String name
-) {
-	public static GoalResponseVO of(GoalType goalType) {
-		return new GoalResponseVO(goalType.name(), goalType.getDescription());
-	}
+    record GoalResponseVO(
+            @Schema(description = "학습 목표 ENUM 값", example = "APPLY")
+            String goalType,
+            @Schema(description = "학습 목표 이름", example = "현지 언어 체득")
+            String name
+    ) {
+        public static GoalResponseVO of(GoalType goalType) {
+            return new GoalResponseVO(goalType.name(), goalType.getDescription());
+        }
+    }
 }

--- a/src/main/java/com/smeme/server/dto/member/MemberGetResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberGetResponseDTO.java
@@ -6,8 +6,6 @@ import com.smeme.server.model.Member;
 import com.smeme.server.model.goal.Goal;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.util.List;
-
 public record MemberGetResponseDTO(
         @Schema(description = "회원 아이디", example = "test")
         String username,
@@ -15,8 +13,7 @@ public record MemberGetResponseDTO(
         String target,
         @Schema(description = "목표 달성 방법", example = "주 5회 이상 오늘 하루를 돌아보는 일기 작성하기")
         String way,
-        @Schema(description = "목표 세부 내용", example = "사전 없이 일기 완성\n" +
-                "smeem 연속 일기 배지 획득")
+        @Schema(description = "목표 세부 내용", example = "사전 없이 일기 완성\nsmeem 연속 일기 배지 획득")
         String detail,
         @Schema(description = "목표 언어", example = "en")
         String targetLang,
@@ -27,7 +24,7 @@ public record MemberGetResponseDTO(
         @Schema(description = "뱃지")
         BadgeResponseDTO badge) {
 
-    public static MemberGetResponseDTO of(Goal goal,Member member, TrainingTimeResponseDTO trainingTime, BadgeResponseDTO badge) {
+    public static MemberGetResponseDTO of(Goal goal, Member member, TrainingTimeResponseDTO trainingTime, BadgeResponseDTO badge) {
         return new MemberGetResponseDTO(
                 member.getUsername(),
                 member.getGoal().getDescription(),

--- a/src/main/java/com/smeme/server/dto/member/MemberNameResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberNameResponseDTO.java
@@ -4,5 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record MemberNameResponseDTO(
         @Schema(description = "회원 이름 존재 여부", example = "true")
-        boolean isExist) {
+        boolean isExist
+) {
 }

--- a/src/main/java/com/smeme/server/dto/member/MemberPlanUpdateRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberPlanUpdateRequestDTO.java
@@ -9,10 +9,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record MemberPlanUpdateRequestDTO(
         @Schema(description = "목표 타입", example = "HOBBY")
         GoalType target,
-
         @Schema(description = "학습 시간")
         TrainingTimeRequestDTO trainingTime,
-
         @Schema(description = "알람 여부", example = "true")
         Boolean hasAlarm
 ) {

--- a/src/main/java/com/smeme/server/dto/member/MemberPushRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberPushRequestDTO.java
@@ -1,2 +1,0 @@
-package com.smeme.server.dto.member;public record MemberPushRequestDTO() {
-}

--- a/src/main/java/com/smeme/server/dto/member/MemberUpdateRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberUpdateRequestDTO.java
@@ -6,7 +6,6 @@ public record MemberUpdateRequestDTO(
         @Schema(description = "회원 이름", example = "홍길동")
         @ValidUsername
         String username,
-
         @Schema(description = "정책 동의 여부", example = "false")
         Boolean termAccepted
 ) {

--- a/src/main/java/com/smeme/server/dto/member/MemberUpdateResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/member/MemberUpdateResponseDTO.java
@@ -1,7 +1,6 @@
 package com.smeme.server.dto.member;
 
 import com.smeme.server.model.badge.Badge;
-import com.smeme.server.model.badge.MemberBadge;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
@@ -16,12 +15,9 @@ public record MemberUpdateResponseDTO(
     record BadgeDTO(
             @Schema(description = "뱃지 이름", example = "웰컴뱃지")
             String name,
-
             @Schema(description = "뱃지 이미지 url", example = "https://m.s3.ap-northeast-2.amazonaws.com/badge/welcome.png")
             String imageUrl
     ) {
-
     }
-
 }
 

--- a/src/main/java/com/smeme/server/dto/member/UsernameValidator.java
+++ b/src/main/java/com/smeme/server/dto/member/UsernameValidator.java
@@ -6,10 +6,6 @@ import jakarta.validation.ConstraintValidatorContext;
 public class UsernameValidator implements ConstraintValidator<ValidUsername, String> {
 
     @Override
-    public void initialize(ValidUsername constraintAnnotation) {
-    }
-
-    @Override
     public boolean isValid(String username, ConstraintValidatorContext context) {
 
         // null, 공백으로만 이뤄지는 경우, 빈 값인 경우 ''
@@ -18,9 +14,10 @@ public class UsernameValidator implements ConstraintValidator<ValidUsername, Str
         }
 
         // 길이가 1보다 작거나 10보다 큰 경우
-        if (username.length() < 1 || username.length() > 10) {
+        if (username.isEmpty() || username.length() > 10) {
             return false;
         }
+
         // 첫 글자가 공백인 경우
         return !(username.charAt(0) == ' ');
     }

--- a/src/main/java/com/smeme/server/dto/message/MessageDTO.java
+++ b/src/main/java/com/smeme/server/dto/message/MessageDTO.java
@@ -4,18 +4,18 @@ import lombok.Builder;
 
 @Builder
 public record MessageDTO(
-	boolean validateOnly,
-	MessageVO message
+        boolean validateOnly,
+        MessageVO message
 ) {
-	public static MessageDTO of(String targetToken, String title, String body) {
-		NotificationVO notification = new NotificationVO(title, body);
-		MessageVO message = new MessageVO(notification, targetToken);
-		return new MessageDTO(false, message);
-	}
-}
+    public static MessageDTO of(String targetToken, String title, String body) {
+        NotificationVO notification = new NotificationVO(title, body);
+        MessageVO message = new MessageVO(notification, targetToken);
+        return new MessageDTO(false, message);
+    }
 
-record MessageVO(NotificationVO notification, String token) {
-}
+    record MessageVO(NotificationVO notification, String token) {
+    }
 
-record NotificationVO(String title, String body) {
+    record NotificationVO(String title, String body) {
+    }
 }

--- a/src/main/java/com/smeme/server/dto/topic/TopicResponseDTO.java
+++ b/src/main/java/com/smeme/server/dto/topic/TopicResponseDTO.java
@@ -5,13 +5,12 @@ import com.smeme.server.model.topic.Topic;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record TopicResponseDTO(
-	@Schema(description = "랜덤 주제 id", example = "1")
-	Long topicId,
-
-	@Schema(description = "랜덤 주제 내용", example = "가보고 싶은 해외 여행지가 있다면 소개해 주세요!")
-	String content
+        @Schema(description = "랜덤 주제 id", example = "1")
+        Long topicId,
+        @Schema(description = "랜덤 주제 내용", example = "가보고 싶은 해외 여행지가 있다면 소개해 주세요!")
+        String content
 ) {
-	public static TopicResponseDTO of (Topic topic) {
-		return new TopicResponseDTO(topic.getId(), topic.getContent());
-	}
+    public static TopicResponseDTO of(Topic topic) {
+        return new TopicResponseDTO(topic.getId(), topic.getContent());
+    }
 }

--- a/src/main/java/com/smeme/server/dto/training/TrainingTimeRequestDTO.java
+++ b/src/main/java/com/smeme/server/dto/training/TrainingTimeRequestDTO.java
@@ -3,13 +3,10 @@ package com.smeme.server.dto.training;
 import jakarta.validation.constraints.NotNull;
 
 public record TrainingTimeRequestDTO(
-
         @NotNull
         String day,
-
         @NotNull
         int hour,
-
         @NotNull
         int minute
 ) {

--- a/src/main/java/com/smeme/server/model/BaseTimeEntity.java
+++ b/src/main/java/com/smeme/server/model/BaseTimeEntity.java
@@ -1,7 +1,5 @@
 package com.smeme.server.model;
 
-
-import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;

--- a/src/main/java/com/smeme/server/model/Correction.java
+++ b/src/main/java/com/smeme/server/model/Correction.java
@@ -18,39 +18,40 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Correction {
 
-	@Id @GeneratedValue(strategy = IDENTITY)
-	@Column(name = "correction_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "correction_id")
+    private Long id;
 
-	private String beforeSentence;
+    private String beforeSentence;
 
-	private String afterSentence;
+    private String afterSentence;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "diary_id")
-	private Diary diary;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
 
-	public Correction(String beforeSentence, String afterSentence, Diary diary) {
-		this.beforeSentence = beforeSentence;
-		this.afterSentence = afterSentence;
-		setDiary(diary);
-	}
+    public Correction(String beforeSentence, String afterSentence, Diary diary) {
+        this.beforeSentence = beforeSentence;
+        this.afterSentence = afterSentence;
+        setDiary(diary);
+    }
 
-	public void deleteCorrection() {
-		if (nonNull(this.diary)) {
-			this.diary.getCorrections().remove(this);
-		}
-	}
+    public void deleteCorrection() {
+        if (nonNull(this.diary)) {
+            this.diary.getCorrections().remove(this);
+        }
+    }
 
-	public void updateCorrection(String content) {
-		this.afterSentence = content;
-	}
+    public void updateCorrection(String content) {
+        this.afterSentence = content;
+    }
 
-	private void setDiary(Diary diary) {
-		if (nonNull(this.diary)) {
-			this.diary.getCorrections().remove(this);
-		}
-		this.diary = diary;
-		diary.getCorrections().add(this);
-	}
+    private void setDiary(Diary diary) {
+        if (nonNull(this.diary)) {
+            this.diary.getCorrections().remove(this);
+        }
+        this.diary = diary;
+        diary.getCorrections().add(this);
+    }
 }

--- a/src/main/java/com/smeme/server/model/Diary.java
+++ b/src/main/java/com/smeme/server/model/Diary.java
@@ -19,7 +19,8 @@ import com.smeme.server.model.topic.Topic;
 @Getter
 public class Diary extends BaseTimeEntity {
 
-    @Id @GeneratedValue(strategy = IDENTITY)
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
     @Column(name = "diary_id")
     private Long id;
 

--- a/src/main/java/com/smeme/server/model/Member.java
+++ b/src/main/java/com/smeme/server/model/Member.java
@@ -19,7 +19,8 @@ import com.smeme.server.model.goal.GoalType;
 @Getter
 public class Member extends BaseTimeEntity {
 
-    @Id @GeneratedValue(strategy = IDENTITY)
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
     @Column(name = "member_id")
     private Long id;
 
@@ -57,7 +58,6 @@ public class Member extends BaseTimeEntity {
     @OneToMany(mappedBy = "member")
     private final List<MemberBadge> badges = new ArrayList<>();
 
-
     @Builder
     public Member(SocialType social, String socialId, LangType targetLang, String fcmToken) {
         this.social = social;
@@ -67,16 +67,23 @@ public class Member extends BaseTimeEntity {
         this.goal = null;
     }
 
-    public void updateFcmToken(String fcmToken) {this.fcmToken = fcmToken; }
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
 
-    public void updateUsername(String username) { this.username = username; }
+    public void updateUsername(String username) {
+        this.username = username;
+    }
 
-    public void updateTermAccepted(boolean termAccepted) { this.termAccepted = termAccepted; }
+    public void updateTermAccepted(boolean termAccepted) {
+        this.termAccepted = termAccepted;
+    }
 
-    public void updateHasAlarm(boolean hasAlarm) { this.hasPushAlarm = hasAlarm; }
+    public void updateHasAlarm(boolean hasAlarm) {
+        this.hasPushAlarm = hasAlarm;
+    }
 
-    public void updateGoal(GoalType goal) {this.goal = goal; }
+    public void updateGoal(GoalType goal) {
+        this.goal = goal;
+    }
 }

--- a/src/main/java/com/smeme/server/model/SocialType.java
+++ b/src/main/java/com/smeme/server/model/SocialType.java
@@ -1,5 +1,7 @@
 package com.smeme.server.model;
 
 public enum SocialType {
-    KAKAO, APPLE, BETA
+    KAKAO,
+    APPLE,
+    BETA
 }

--- a/src/main/java/com/smeme/server/model/badge/Badge.java
+++ b/src/main/java/com/smeme/server/model/badge/Badge.java
@@ -13,13 +13,14 @@ import lombok.Getter;
 @Getter
 public class Badge {
 
-	@Id @GeneratedValue(strategy = IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
 
-	@Enumerated(value = EnumType.STRING)
-	private BadgeType type;
+    @Enumerated(value = EnumType.STRING)
+    private BadgeType type;
 
-	private String name;
+    private String name;
 
-	private String imageUrl;
+    private String imageUrl;
 }

--- a/src/main/java/com/smeme/server/model/badge/BadgeType.java
+++ b/src/main/java/com/smeme/server/model/badge/BadgeType.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum BadgeType {
-	EVENT("Event"),
-	COUNTING("Diary Counting"),
-	COMBO("Diary Combo"),
-	EXPLORATION("Exploration");
+    EVENT("Event"),
+    COUNTING("Diary Counting"),
+    COMBO("Diary Combo"),
+    EXPLORATION("Exploration");
 
-	private final String description;
+    private final String description;
 }

--- a/src/main/java/com/smeme/server/model/badge/MemberBadge.java
+++ b/src/main/java/com/smeme/server/model/badge/MemberBadge.java
@@ -13,39 +13,37 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor
 @Getter
 public class MemberBadge extends BaseTimeEntity {
 
-	@Id @GeneratedValue(strategy = IDENTITY)
-	@Column(name = "member_badge_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "member_badge_id")
+    private Long id;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "member_id")
-	private Member member;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "badge_id")
-	private Badge badge;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "badge_id")
+    private Badge badge;
 
-	public MemberBadge(Member member, Badge badge) {
-		setMember(member);
-		this.badge = badge;
-	}
+    public MemberBadge(Member member, Badge badge) {
+        setMember(member);
+        this.badge = badge;
+    }
 
-	private void setMember(Member member) {
-		if (nonNull(this.member)) {
-			this.member.getBadges().remove(this);
-		}
-		this.member = member;
-		member.getBadges().add(this);
-	}
+    private void setMember(Member member) {
+        if (nonNull(this.member)) {
+            this.member.getBadges().remove(this);
+        }
+        this.member = member;
+        member.getBadges().add(this);
+    }
 }

--- a/src/main/java/com/smeme/server/model/goal/Goal.java
+++ b/src/main/java/com/smeme/server/model/goal/Goal.java
@@ -14,15 +14,16 @@ import lombok.Getter;
 @Getter
 public class Goal {
 
-	@Id @GeneratedValue(strategy = IDENTITY)
-	@Column(name = "goal_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "goal_id")
+    private Long id;
 
-	@Column(unique = true)
-	@Enumerated(value = EnumType.STRING)
-	private GoalType type;
+    @Column(unique = true)
+    @Enumerated(value = EnumType.STRING)
+    private GoalType type;
 
-	private String way;
+    private String way;
 
-	private String detail;
+    private String detail;
 }

--- a/src/main/java/com/smeme/server/model/goal/GoalType.java
+++ b/src/main/java/com/smeme/server/model/goal/GoalType.java
@@ -6,12 +6,12 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum GoalType {
-	DEVELOP("자기계발"),
-	HOBBY("취미로 즐기기"),
-	APPLY("현지 언어 체득"),
-	BUSINESS("유창한 비즈니스 영어"),
-	EXAM("어학 시험 고득점"),
-	NONE("아직 모르겠어요");
+    DEVELOP("자기계발"),
+    HOBBY("취미로 즐기기"),
+    APPLY("현지 언어 체득"),
+    BUSINESS("유창한 비즈니스 영어"),
+    EXAM("어학 시험 고득점"),
+    NONE("아직 모르겠어요");
 
-	private final String description;
+    private final String description;
 }

--- a/src/main/java/com/smeme/server/model/topic/Category.java
+++ b/src/main/java/com/smeme/server/model/topic/Category.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum Category {
-	TRIP("여행"),
-	TASTE("취향"),
-	DEVELOP("자기계발"),
-	PREVIEW("시사");
+    TRIP("여행"),
+    TASTE("취향"),
+    DEVELOP("자기계발"),
+    PREVIEW("시사");
 
-	private final String name;
+    private final String name;
 }

--- a/src/main/java/com/smeme/server/model/topic/Topic.java
+++ b/src/main/java/com/smeme/server/model/topic/Topic.java
@@ -11,7 +11,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Topic {
 
-    @Id @GeneratedValue(strategy = IDENTITY)
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
     @Column(name = "topic_id")
     private Long id;
 

--- a/src/main/java/com/smeme/server/model/training/DayType.java
+++ b/src/main/java/com/smeme/server/model/training/DayType.java
@@ -6,13 +6,13 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum DayType {
-	MON("월"),
-	TUE("화"),
-	WED("수"),
-	THU("목"),
-	FRI("금"),
-	SAT("토"),
-	SUN("일");
+    MON("월"),
+    TUE("화"),
+    WED("수"),
+    THU("목"),
+    FRI("금"),
+    SAT("토"),
+    SUN("일");
 
-	private final String name;
+    private final String name;
 }

--- a/src/main/java/com/smeme/server/model/training/TrainingTime.java
+++ b/src/main/java/com/smeme/server/model/training/TrainingTime.java
@@ -24,37 +24,38 @@ import lombok.NoArgsConstructor;
 @Getter
 public class TrainingTime {
 
-	@Id @GeneratedValue(strategy = IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
 
-	@Enumerated(value = EnumType.STRING)
-	private DayType day;
+    @Enumerated(value = EnumType.STRING)
+    private DayType day;
 
-	@Min(value = 1, message = "시(hour)는 1 이상이어야 합니다.")
-	@Max(value = 24, message = "시(hour)는 24 이하여야 합니다.")
-	private int hour;
+    @Min(value = 1, message = "시(hour)는 1 이상이어야 합니다.")
+    @Max(value = 24, message = "시(hour)는 24 이하여야 합니다.")
+    private int hour;
 
-	@Min(value = 0, message = "분(minute)은 0 이상이어야 합니다.")
-	@Max(value = 59, message = "분(minute)은 59 이하이어야 합니다.")
-	private int minute;
+    @Min(value = 0, message = "분(minute)은 0 이상이어야 합니다.")
+    @Max(value = 59, message = "분(minute)은 59 이하이어야 합니다.")
+    private int minute;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "member_id")
-	private Member member;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
-	@Builder
-	public TrainingTime(DayType day, int hour, int minute, Member member) {
-		this.day = day;
-		this.hour = hour;
-		this.minute = minute;
-		setMember(member);
-	}
+    @Builder
+    public TrainingTime(DayType day, int hour, int minute, Member member) {
+        this.day = day;
+        this.hour = hour;
+        this.minute = minute;
+        setMember(member);
+    }
 
-	private void setMember(Member member) {
-		if (nonNull(this.member)) {
-			this.member.getTrainingTimes().remove(this);
-		}
-		this.member = member;
-		member.getTrainingTimes().add(this);
-	}
+    private void setMember(Member member) {
+        if (nonNull(this.member)) {
+            this.member.getTrainingTimes().remove(this);
+        }
+        this.member = member;
+        member.getTrainingTimes().add(this);
+    }
 }

--- a/src/main/java/com/smeme/server/repository/badge/MemberBadgeRepository.java
+++ b/src/main/java/com/smeme/server/repository/badge/MemberBadgeRepository.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long> {
 
     List<MemberBadge> findAllByMemberId(Long memberId);
+
     boolean existsByMemberAndBadge(Member member, Badge badge);
 
     Optional<MemberBadge> findFirstByMemberIdOrderByCreatedAtDesc(Long memberId);

--- a/src/main/java/com/smeme/server/repository/correction/CorrectionCustomRepository.java
+++ b/src/main/java/com/smeme/server/repository/correction/CorrectionCustomRepository.java
@@ -3,5 +3,5 @@ package com.smeme.server.repository.correction;
 import com.smeme.server.model.Member;
 
 public interface CorrectionCustomRepository {
-	int countCorrection(Member member);
+    int countCorrection(Member member);
 }

--- a/src/main/java/com/smeme/server/repository/correction/CorrectionRepository.java
+++ b/src/main/java/com/smeme/server/repository/correction/CorrectionRepository.java
@@ -8,7 +8,7 @@ import com.smeme.server.model.Correction;
 import com.smeme.server.model.Diary;
 
 public interface CorrectionRepository extends JpaRepository<Correction, Long>, CorrectionCustomRepository {
-	List<Correction> findByDiaryOrderByIdDesc(Diary diary);
+    List<Correction> findByDiaryOrderByIdDesc(Diary diary);
 
-	void deleteAllByDiaryId(Long id);
+    void deleteAllByDiaryId(Long id);
 }

--- a/src/main/java/com/smeme/server/repository/correction/CorrectionRepositoryImpl.java
+++ b/src/main/java/com/smeme/server/repository/correction/CorrectionRepositoryImpl.java
@@ -15,18 +15,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CorrectionRepositoryImpl implements CorrectionCustomRepository {
 
-	private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
 
-	@Override
-	public int countCorrection(Member member) {
-		return Math.toIntExact(queryFactory
-			.select(correction.count())
-			.from(correction)
-			.leftJoin(correction.diary, diary)
-			.where(
-				diary.member.eq(member),
-				diary.isDeleted.eq(false)
-			)
-			.fetchFirst());
-	}
+    @Override
+    public int countCorrection(Member member) {
+        return Math.toIntExact(queryFactory
+                .select(correction.count())
+                .from(correction)
+                .leftJoin(correction.diary, diary)
+                .where(
+                        diary.member.eq(member),
+                        diary.isDeleted.eq(false)
+                )
+                .fetchFirst());
+    }
 }

--- a/src/main/java/com/smeme/server/repository/diary/DiaryCustomRepository.java
+++ b/src/main/java/com/smeme/server/repository/diary/DiaryCustomRepository.java
@@ -7,9 +7,13 @@ import com.smeme.server.model.Diary;
 import com.smeme.server.model.Member;
 
 public interface DiaryCustomRepository {
-	boolean existTodayDiary(Member member);
-	List<Diary> findDiariesStartToEnd(Member member, LocalDateTime startDate, LocalDateTime endDate);
-	boolean exist30PastDiary(Member member);
-	List<Diary> findDiariesDeleted30Past(LocalDateTime past);
-	boolean existDiaryInDate(Member member, LocalDateTime createdDate);
+    boolean existTodayDiary(Member member);
+
+    List<Diary> findDiariesStartToEnd(Member member, LocalDateTime startDate, LocalDateTime endDate);
+
+    boolean exist30PastDiary(Member member);
+
+    List<Diary> findDiariesDeleted30Past(LocalDateTime past);
+
+    boolean existDiaryInDate(Member member, LocalDateTime createdDate);
 }

--- a/src/main/java/com/smeme/server/repository/diary/DiaryRepositoryImpl.java
+++ b/src/main/java/com/smeme/server/repository/diary/DiaryRepositoryImpl.java
@@ -17,81 +17,81 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class DiaryRepositoryImpl implements DiaryCustomRepository {
 
-	private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
 
-	@Override
-	public boolean existTodayDiary(Member member) {
-		LocalDateTime now = LocalDateTime.now();
-		return queryFactory
-			.from(diary)
-			.where(
-				diary.member.eq(member),
-				diary.createdAt.between(get12midnight(now), now),
-				diary.isDeleted.eq(false)
-			)
-			.select(diary.id)
-			.fetchFirst() != null;
-	}
+    @Override
+    public boolean existTodayDiary(Member member) {
+        LocalDateTime now = LocalDateTime.now();
+        return queryFactory
+                .from(diary)
+                .where(
+                        diary.member.eq(member),
+                        diary.createdAt.between(get12midnight(now), now),
+                        diary.isDeleted.eq(false)
+                )
+                .select(diary.id)
+                .fetchFirst() != null;
+    }
 
-	@Override
-	public List<Diary> findDiariesStartToEnd(Member member, LocalDateTime startDate, LocalDateTime endDate) {
-		return queryFactory
-			.select(diary)
-			.from(diary)
-			.where(
-				diary.member.eq(member),
-				diary.createdAt.between(startDate, endDate),
-				diary.isDeleted.eq(false)
-				)
-			.fetch();
-	}
+    @Override
+    public List<Diary> findDiariesStartToEnd(Member member, LocalDateTime startDate, LocalDateTime endDate) {
+        return queryFactory
+                .select(diary)
+                .from(diary)
+                .where(
+                        diary.member.eq(member),
+                        diary.createdAt.between(startDate, endDate),
+                        diary.isDeleted.eq(false)
+                )
+                .fetch();
+    }
 
-	@Override
-	public boolean exist30PastDiary(Member member) {
-		LocalDateTime past = LocalDateTime.now().minusDays(30);
-		return queryFactory
-			.select(diary)
-			.from(diary)
-			.where(
-				diary.member.eq(member),
-				diary.createdAt.year().eq(past.getYear()),
-				diary.createdAt.month().eq(past.getMonthValue()),
-				diary.createdAt.dayOfMonth().eq(past.getDayOfMonth()),
-				diary.isDeleted.eq(false)
-			)
-			.fetchFirst() != null;
-	}
+    @Override
+    public boolean exist30PastDiary(Member member) {
+        LocalDateTime past = LocalDateTime.now().minusDays(30);
+        return queryFactory
+                .select(diary)
+                .from(diary)
+                .where(
+                        diary.member.eq(member),
+                        diary.createdAt.year().eq(past.getYear()),
+                        diary.createdAt.month().eq(past.getMonthValue()),
+                        diary.createdAt.dayOfMonth().eq(past.getDayOfMonth()),
+                        diary.isDeleted.eq(false)
+                )
+                .fetchFirst() != null;
+    }
 
-	@Override
-	public List<Diary> findDiariesDeleted30Past(LocalDateTime past) {
-		return queryFactory
-			.select(diary)
-			.from(diary)
-			.where(
-				diary.isDeleted.eq(true),
-				diary.updatedAt.year().eq(past.getYear()),
-				diary.updatedAt.month().eq(past.getMonthValue()),
-				diary.updatedAt.dayOfMonth().eq(past.getDayOfMonth())
-			)
-			.fetch();
-	}
+    @Override
+    public List<Diary> findDiariesDeleted30Past(LocalDateTime past) {
+        return queryFactory
+                .select(diary)
+                .from(diary)
+                .where(
+                        diary.isDeleted.eq(true),
+                        diary.updatedAt.year().eq(past.getYear()),
+                        diary.updatedAt.month().eq(past.getMonthValue()),
+                        diary.updatedAt.dayOfMonth().eq(past.getDayOfMonth())
+                )
+                .fetch();
+    }
 
-	@Override
-	public boolean existDiaryInDate(Member member, LocalDateTime createdDate) {
-		return queryFactory
-			.select(diary)
-			.from(diary)
-			.where(
-				diary.member.eq(member),
-				diary.createdAt.year().eq(createdDate.getYear()),
-				diary.createdAt.month().eq(createdDate.getMonthValue()),
-				diary.createdAt.dayOfMonth().eq(createdDate.getDayOfMonth()),
-				diary.isDeleted.eq(false)
-			)
-			.fetchFirst() != null;
-	}
+    @Override
+    public boolean existDiaryInDate(Member member, LocalDateTime createdDate) {
+        return queryFactory
+                .select(diary)
+                .from(diary)
+                .where(
+                        diary.member.eq(member),
+                        diary.createdAt.year().eq(createdDate.getYear()),
+                        diary.createdAt.month().eq(createdDate.getMonthValue()),
+                        diary.createdAt.dayOfMonth().eq(createdDate.getDayOfMonth()),
+                        diary.isDeleted.eq(false)
+                )
+                .fetchFirst() != null;
+    }
 
-	private LocalDateTime get12midnight(LocalDateTime now) {
-		return LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(), 0, 0, 0);
-	}
+    private LocalDateTime get12midnight(LocalDateTime now) {
+        return LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(), 0, 0, 0);
+    }
 }

--- a/src/main/java/com/smeme/server/repository/topic/TopicCustomRepository.java
+++ b/src/main/java/com/smeme/server/repository/topic/TopicCustomRepository.java
@@ -3,5 +3,5 @@ package com.smeme.server.repository.topic;
 import com.smeme.server.model.topic.Topic;
 
 public interface TopicCustomRepository {
-	Topic getRandomTopic();
+    Topic getRandomTopic();
 }

--- a/src/main/java/com/smeme/server/repository/topic/TopicRepositoryImpl.java
+++ b/src/main/java/com/smeme/server/repository/topic/TopicRepositoryImpl.java
@@ -14,15 +14,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TopicRepositoryImpl implements TopicCustomRepository {
 
-	private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
 
-	@Override
-	public Topic getRandomTopic() {
-		return queryFactory
-			.select(topic)
-			.from(topic)
-			.orderBy(random().asc())
-			.limit(1)
-			.fetchFirst();
-	}
+    @Override
+    public Topic getRandomTopic() {
+        return queryFactory
+                .select(topic)
+                .from(topic)
+                .orderBy(random().asc())
+                .limit(1)
+                .fetchFirst();
+    }
 }

--- a/src/main/java/com/smeme/server/repository/trainingTime/TrainingTimeCustomRepository.java
+++ b/src/main/java/com/smeme/server/repository/trainingTime/TrainingTimeCustomRepository.java
@@ -6,5 +6,5 @@ import java.util.List;
 import com.smeme.server.model.training.TrainingTime;
 
 public interface TrainingTimeCustomRepository {
-	List<TrainingTime> getTrainingTimeForPushAlarm(LocalDateTime now);
+    List<TrainingTime> getTrainingTimeForPushAlarm(LocalDateTime now);
 }

--- a/src/main/java/com/smeme/server/repository/trainingTime/TrainingTimeRepositoryImpl.java
+++ b/src/main/java/com/smeme/server/repository/trainingTime/TrainingTimeRepositoryImpl.java
@@ -20,33 +20,33 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TrainingTimeRepositoryImpl implements TrainingTimeCustomRepository {
 
-	private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
 
-	@Override
-	public List<TrainingTime> getTrainingTimeForPushAlarm(LocalDateTime now) {
-		return queryFactory
-			.select(trainingTime)
-			.from(trainingTime)
-			.join(trainingTime.member, member).fetchJoin()
-			.where(
-				trainingTime.day.eq(getDayType(now.getDayOfWeek().getValue())),
-				trainingTime.hour.eq(now.getHour()),
-				trainingTime.minute.eq(now.getMinute()),
-				member.hasPushAlarm.eq(true)
-			)
-			.fetch();
-	}
+    @Override
+    public List<TrainingTime> getTrainingTimeForPushAlarm(LocalDateTime now) {
+        return queryFactory
+                .select(trainingTime)
+                .from(trainingTime)
+                .join(trainingTime.member, member).fetchJoin()
+                .where(
+                        trainingTime.day.eq(getDayType(now.getDayOfWeek().getValue())),
+                        trainingTime.hour.eq(now.getHour()),
+                        trainingTime.minute.eq(now.getMinute()),
+                        member.hasPushAlarm.eq(true)
+                )
+                .fetch();
+    }
 
-	private DayType getDayType(int dayValue) {
-		return switch (dayValue) {
-			case 1 -> MON;
-			case 2 -> TUE;
-			case 3 -> WED;
-			case 4 -> THU;
-			case 5 -> FRI;
-			case 6 -> SAT;
-			case 7 -> SUN;
-			default -> throw new RuntimeException(INVALID_DAY_OF_WEEK.getMessage());
-		};
-	}
+    private DayType getDayType(int dayValue) {
+        return switch (dayValue) {
+            case 1 -> MON;
+            case 2 -> TUE;
+            case 3 -> WED;
+            case 4 -> THU;
+            case 5 -> FRI;
+            case 6 -> SAT;
+            case 7 -> SUN;
+            default -> throw new RuntimeException(INVALID_DAY_OF_WEEK.getMessage());
+        };
+    }
 }

--- a/src/main/java/com/smeme/server/service/BadgeService.java
+++ b/src/main/java/com/smeme/server/service/BadgeService.java
@@ -21,7 +21,7 @@ public class BadgeService {
     private final MemberBadgeRepository memberBadgeRepository;
 
     public BadgeListResponseDTO getBadgeList(Long memberId) {
-        List<BadgeResponseDTO> badgeResponseDTOList =  memberBadgeRepository.findAllByMemberId(memberId)
+        List<BadgeResponseDTO> badgeResponseDTOList = memberBadgeRepository.findAllByMemberId(memberId)
                 .stream()
                 .map(BadgeResponseDTO::of)
                 .toList();

--- a/src/main/java/com/smeme/server/service/CorrectionService.java
+++ b/src/main/java/com/smeme/server/service/CorrectionService.java
@@ -28,71 +28,71 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class CorrectionService {
 
-	private final CorrectionRepository correctionRepository;
-	private final DiaryRepository diaryRepository;
-	private final MemberRepository memberRepository;
-	private final BadgeRepository badgeRepository;
-	private final MemberBadgeRepository memberBadgeRepository;
-	private final BadgeService badgeService;
+    private final CorrectionRepository correctionRepository;
+    private final DiaryRepository diaryRepository;
+    private final MemberRepository memberRepository;
+    private final BadgeRepository badgeRepository;
+    private final MemberBadgeRepository memberBadgeRepository;
+    private final BadgeService badgeService;
 
-	@Transactional
-	public CorrectionResponseDTO createCorrection(Long memberId, Long diaryId, CorrectionRequestDTO requestDTO) {
-		Diary diary = getDiary(diaryId);
-		correctionRepository.save(new Correction(requestDTO.sentence(), requestDTO.content(), diary));
-		Member member = getMember(memberId);
-		Badge badge = getCorrectionBadge(member);
-		if (Objects.nonNull(badge) && !memberBadgeRepository.existsByMemberAndBadge(member, badge)) {
-			badgeService.createMemberBadge(member, badge);
-		}
-		return new CorrectionResponseDTO(diaryId, badge);
-	}
+    @Transactional
+    public CorrectionResponseDTO createCorrection(Long memberId, Long diaryId, CorrectionRequestDTO requestDTO) {
+        Diary diary = getDiary(diaryId);
+        correctionRepository.save(new Correction(requestDTO.sentence(), requestDTO.content(), diary));
+        Member member = getMember(memberId);
+        Badge badge = getCorrectionBadge(member);
+        if (Objects.nonNull(badge) && !memberBadgeRepository.existsByMemberAndBadge(member, badge)) {
+            badgeService.createMemberBadge(member, badge);
+        }
+        return new CorrectionResponseDTO(diaryId, badge);
+    }
 
-	private Badge getCorrectionBadge(Member member) {
-		int count = correctionRepository.countCorrection(member);
-		if (count == 5) {
-			return getBadge(12L);
-		} else if (count == 3) {
-			return getBadge(11L);
-		} else if (count == 1) {
-			return getBadge(10L);
-		}
-		return null;
-	}
+    private Badge getCorrectionBadge(Member member) {
+        int count = correctionRepository.countCorrection(member);
+        if (count == 5) {
+            return getBadge(12L);
+        } else if (count == 3) {
+            return getBadge(11L);
+        } else if (count == 1) {
+            return getBadge(10L);
+        }
+        return null;
+    }
 
-	@Transactional
-	public void deleteCorrection(Long correctionId) {
-		Correction correction = getCorrection(correctionId);
-		correction.deleteCorrection();
-		correctionRepository.deleteById(correctionId);
-	}
+    @Transactional
+    public void deleteCorrection(Long correctionId) {
+        Correction correction = getCorrection(correctionId);
+        correction.deleteCorrection();
+        correctionRepository.deleteById(correctionId);
+    }
 
-	@Transactional
-	public void updateCorrection(Long correctionId, CorrectionRequestDTO requestDTO) {
-		Correction correction = getCorrection(correctionId);
-		correction.updateCorrection(requestDTO.content());
-	}
+    @Transactional
+    public void updateCorrection(Long correctionId, CorrectionRequestDTO requestDTO) {
+        Correction correction = getCorrection(correctionId);
+        correction.updateCorrection(requestDTO.content());
+    }
 
-	private Diary getDiary(Long diaryId) {
-		Diary diary = diaryRepository.findById(diaryId)
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_DIARY.getMessage()));
-		if (diary.isDeleted()) {
-			throw new NoSuchElementException(DELETED_DIARY.getMessage());
-		}
-		return diary;
-	}
+    private Diary getDiary(Long diaryId) {
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new EntityNotFoundException(INVALID_DIARY.getMessage()));
+        if (diary.isDeleted()) {
+            throw new NoSuchElementException(DELETED_DIARY.getMessage());
+        }
+        return diary;
+    }
 
-	private Correction getCorrection(Long correctionId) {
-		return correctionRepository.findById(correctionId)
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_CORRECTION.getMessage()));
-	}
+    private Correction getCorrection(Long correctionId) {
+        return correctionRepository.findById(correctionId)
+                .orElseThrow(() -> new EntityNotFoundException(INVALID_CORRECTION.getMessage()));
+    }
 
-	private Member getMember(Long memberId) {
-		return memberRepository.findById(memberId)
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_MEMBER.getMessage()));
-	}
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException(INVALID_MEMBER.getMessage()));
+    }
 
-	private Badge getBadge(Long id) {
-		return badgeRepository.findById(id)
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_BADGE.getMessage()));
-	}
+    private Badge getBadge(Long id) {
+        return badgeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(INVALID_BADGE.getMessage()));
+    }
 }

--- a/src/main/java/com/smeme/server/service/CorrectionService.java
+++ b/src/main/java/com/smeme/server/service/CorrectionService.java
@@ -36,9 +36,9 @@ public class CorrectionService {
     private final BadgeService badgeService;
 
     @Transactional
-    public CorrectionResponseDTO createCorrection(Long memberId, Long diaryId, CorrectionRequestDTO requestDTO) {
+    public CorrectionResponseDTO createCorrection(Long memberId, Long diaryId, CorrectionRequestDTO request) {
         Diary diary = getDiary(diaryId);
-        correctionRepository.save(new Correction(requestDTO.sentence(), requestDTO.content(), diary));
+        correctionRepository.save(new Correction(request.sentence(), request.content(), diary));
         Member member = getMember(memberId);
         Badge badge = getCorrectionBadge(member);
         if (Objects.nonNull(badge) && !memberBadgeRepository.existsByMemberAndBadge(member, badge)) {
@@ -67,9 +67,9 @@ public class CorrectionService {
     }
 
     @Transactional
-    public void updateCorrection(Long correctionId, CorrectionRequestDTO requestDTO) {
+    public void updateCorrection(Long correctionId, CorrectionRequestDTO request) {
         Correction correction = getCorrection(correctionId);
-        correction.updateCorrection(requestDTO.content());
+        correction.updateCorrection(request.content());
     }
 
     private Diary getDiary(Long diaryId) {

--- a/src/main/java/com/smeme/server/service/DiaryService.java
+++ b/src/main/java/com/smeme/server/service/DiaryService.java
@@ -46,10 +46,10 @@ public class DiaryService {
     private final BadgeService badgeService;
 
     @Transactional
-    public CreatedDiaryResponseDTO createDiary(Long memberId, DiaryRequestDTO requestDTO) {
+    public CreatedDiaryResponseDTO createDiary(Long memberId, DiaryRequestDTO request) {
         Member member = getMember(memberId);
-        Topic topic = getTopic(requestDTO.topicId());
-        Diary diary = checkExistTodayDiary(member, new Diary(requestDTO.content(), topic, member));
+        Topic topic = getTopic(request.topicId());
+        Diary diary = checkExistTodayDiary(member, new Diary(request.content(), topic, member));
         List<Badge> badges = getDiaryBadge(member, diary.getCreatedAt());
         return CreatedDiaryResponseDTO.of(diary.getId(), badges);
     }
@@ -61,9 +61,9 @@ public class DiaryService {
     }
 
     @Transactional
-    public void updateDiary(Long diaryId, DiaryRequestDTO requestDTO) {
+    public void updateDiary(Long diaryId, DiaryRequestDTO request) {
         Diary diary = getDiary(diaryId);
-        diary.updateContent(requestDTO.content());
+        diary.updateContent(request.content());
     }
 
     @Transactional

--- a/src/main/java/com/smeme/server/service/DiaryService.java
+++ b/src/main/java/com/smeme/server/service/DiaryService.java
@@ -37,143 +37,143 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class DiaryService {
 
-	private final DiaryRepository diaryRepository;
-	private final TopicRepository topicRepository;
-	private final MemberRepository memberRepository;
-	private final CorrectionRepository correctionRepository;
-	private final MemberBadgeRepository memberBadgeRepository;
-	private final BadgeRepository badgeRepository;
-	private final BadgeService badgeService;
+    private final DiaryRepository diaryRepository;
+    private final TopicRepository topicRepository;
+    private final MemberRepository memberRepository;
+    private final CorrectionRepository correctionRepository;
+    private final MemberBadgeRepository memberBadgeRepository;
+    private final BadgeRepository badgeRepository;
+    private final BadgeService badgeService;
 
-	@Transactional
-	public CreatedDiaryResponseDTO createDiary(Long memberId, DiaryRequestDTO requestDTO) {
-		Member member = getMember(memberId);
-		Topic topic = getTopic(requestDTO.topicId());
-		Diary diary = checkExistTodayDiary(member, new Diary(requestDTO.content(), topic, member));
-		List<Badge> badges = getDiaryBadge(member, diary.getCreatedAt());
-		return CreatedDiaryResponseDTO.of(diary.getId(), badges);
-	}
+    @Transactional
+    public CreatedDiaryResponseDTO createDiary(Long memberId, DiaryRequestDTO requestDTO) {
+        Member member = getMember(memberId);
+        Topic topic = getTopic(requestDTO.topicId());
+        Diary diary = checkExistTodayDiary(member, new Diary(requestDTO.content(), topic, member));
+        List<Badge> badges = getDiaryBadge(member, diary.getCreatedAt());
+        return CreatedDiaryResponseDTO.of(diary.getId(), badges);
+    }
 
-	public DiaryResponseDTO getDiaryDetail(Long diaryId) {
-		Diary diary = getDiary(diaryId);
-		List<Correction> corrections = correctionRepository.findByDiaryOrderByIdDesc(diary);
-		return DiaryResponseDTO.of(diary, corrections);
-	}
+    public DiaryResponseDTO getDiaryDetail(Long diaryId) {
+        Diary diary = getDiary(diaryId);
+        List<Correction> corrections = correctionRepository.findByDiaryOrderByIdDesc(diary);
+        return DiaryResponseDTO.of(diary, corrections);
+    }
 
-	@Transactional
-	public void updateDiary(Long diaryId, DiaryRequestDTO requestDTO) {
-		Diary diary = getDiary(diaryId);
-		diary.updateContent(requestDTO.content());
-	}
+    @Transactional
+    public void updateDiary(Long diaryId, DiaryRequestDTO requestDTO) {
+        Diary diary = getDiary(diaryId);
+        diary.updateContent(requestDTO.content());
+    }
 
-	@Transactional
-	public void deleteDiary(Long diaryId) {
-		Diary diary = getDiary(diaryId);
-		diary.deleteDiary();
-	}
+    @Transactional
+    public void deleteDiary(Long diaryId) {
+        Diary diary = getDiary(diaryId);
+        diary.deleteDiary();
+    }
 
-	public DiariesResponseDTO getDiaries(Long memberId, String startDate, String endDate) {
-		Member member = getMember(memberId);
-		List<Diary> diaries = diaryRepository.findDiariesStartToEnd(member,
-			transferStringToDateTime(startDate),
-			transferStringToDateTime(endDate).plusDays(1));
-		boolean has30Past = diaryRepository.exist30PastDiary(member);
-		return DiariesResponseDTO.of(diaries, has30Past);
-	}
+    public DiariesResponseDTO getDiaries(Long memberId, String startDate, String endDate) {
+        Member member = getMember(memberId);
+        List<Diary> diaries = diaryRepository.findDiariesStartToEnd(member,
+                transferStringToDateTime(startDate),
+                transferStringToDateTime(endDate).plusDays(1));
+        boolean has30Past = diaryRepository.exist30PastDiary(member);
+        return DiariesResponseDTO.of(diaries, has30Past);
+    }
 
-	@Transactional
-	public void deleteDiary30Past(LocalDateTime past) {
-		diaryRepository.findDiariesDeleted30Past(past)
-			.forEach(this::deleteDiaryRelation);
-	}
+    @Transactional
+    public void deleteDiary30Past(LocalDateTime past) {
+        diaryRepository.findDiariesDeleted30Past(past)
+                .forEach(this::deleteDiaryRelation);
+    }
 
-	private void deleteDiaryRelation(Diary diary) {
-		diary.deleteFromMember();
-		correctionRepository.deleteAll(diary.getCorrections());
-		diaryRepository.deleteById(diary.getId());
-	}
+    private void deleteDiaryRelation(Diary diary) {
+        diary.deleteFromMember();
+        correctionRepository.deleteAll(diary.getCorrections());
+        diaryRepository.deleteById(diary.getId());
+    }
 
-	private Diary getDiary(Long diaryId) {
-		Diary diary = diaryRepository.findById(diaryId)
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_DIARY.getMessage()));
-		if (diary.isDeleted()) {
-			throw new NoSuchElementException(DELETED_DIARY.getMessage());
-		}
-		return diary;
-	}
+    private Diary getDiary(Long diaryId) {
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new EntityNotFoundException(INVALID_DIARY.getMessage()));
+        if (diary.isDeleted()) {
+            throw new NoSuchElementException(DELETED_DIARY.getMessage());
+        }
+        return diary;
+    }
 
-	private Member getMember(Long memberId) {
-		return memberRepository.findById(memberId)
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_MEMBER.getMessage()));
-	}
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException(INVALID_MEMBER.getMessage()));
+    }
 
-	private Topic getTopic(Long topicId) {
-		return nonNull(topicId)
-			? topicRepository.findById(topicId)
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_TOPIC.getMessage()))
-			: null;
-	}
+    private Topic getTopic(Long topicId) {
+        return nonNull(topicId)
+                ? topicRepository.findById(topicId)
+                .orElseThrow(() -> new EntityNotFoundException(INVALID_TOPIC.getMessage()))
+                : null;
+    }
 
-	private Diary checkExistTodayDiary(Member member, Diary diary) {
-		if (diaryRepository.existTodayDiary(member)) {
-			throw new IllegalArgumentException(EXIST_TODAY_DIARY.getMessage());
-		}
-		return diaryRepository.save(diary);
-	}
+    private Diary checkExistTodayDiary(Member member, Diary diary) {
+        if (diaryRepository.existTodayDiary(member)) {
+            throw new IllegalArgumentException(EXIST_TODAY_DIARY.getMessage());
+        }
+        return diaryRepository.save(diary);
+    }
 
-	private LocalDateTime transferStringToDateTime(String str) {
-		return LocalDateTime.parse(str + " 00:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
-	}
+    private LocalDateTime transferStringToDateTime(String str) {
+        return LocalDateTime.parse(str + " 00:00", DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+    }
 
 
-	private List<Badge> getDiaryBadge(Member member, LocalDateTime createdDate) {
-		List<Badge> badges = new ArrayList<>();
-		Badge countingBadge = getCountingDiaryBadge(member);
-		if (Objects.nonNull(countingBadge) && !memberBadgeRepository.existsByMemberAndBadge(member, countingBadge)) {
-			badges.add(countingBadge);
-		}
-		Badge comboBadge = getComboDiaryBadge(member, createdDate);
-		if (Objects.nonNull(comboBadge) && !memberBadgeRepository.existsByMemberAndBadge(member, comboBadge)) {
-			badges.add(comboBadge);
-		}
-		badges.forEach(badge -> badgeService.createMemberBadge(member, badge));
-		return badges;
-	}
+    private List<Badge> getDiaryBadge(Member member, LocalDateTime createdDate) {
+        List<Badge> badges = new ArrayList<>();
+        Badge countingBadge = getCountingDiaryBadge(member);
+        if (Objects.nonNull(countingBadge) && !memberBadgeRepository.existsByMemberAndBadge(member, countingBadge)) {
+            badges.add(countingBadge);
+        }
+        Badge comboBadge = getComboDiaryBadge(member, createdDate);
+        if (Objects.nonNull(comboBadge) && !memberBadgeRepository.existsByMemberAndBadge(member, comboBadge)) {
+            badges.add(comboBadge);
+        }
+        badges.forEach(badge -> badgeService.createMemberBadge(member, badge));
+        return badges;
+    }
 
-	private Badge getComboDiaryBadge(Member member, LocalDateTime createdDate) {
-		int comboCount = 0;
-		while (diaryRepository.existDiaryInDate(member, createdDate)) {
-			comboCount++;
-			createdDate = createdDate.minusDays(1);
-		}
-		if (comboCount == 30) {
-			return getBadge(9L);
-		} else if (comboCount == 15) {
-			return getBadge(8L);
-		} else if (comboCount == 7) {
-			return getBadge(7L);
-		} else if (comboCount == 3) {
-			return getBadge(6L);
-		}
-		return null;
-	}
+    private Badge getComboDiaryBadge(Member member, LocalDateTime createdDate) {
+        int comboCount = 0;
+        while (diaryRepository.existDiaryInDate(member, createdDate)) {
+            comboCount++;
+            createdDate = createdDate.minusDays(1);
+        }
+        if (comboCount == 30) {
+            return getBadge(9L);
+        } else if (comboCount == 15) {
+            return getBadge(8L);
+        } else if (comboCount == 7) {
+            return getBadge(7L);
+        } else if (comboCount == 3) {
+            return getBadge(6L);
+        }
+        return null;
+    }
 
-	private Badge getCountingDiaryBadge(Member member) {
-		int diaryCount = member.getDiaries().stream().filter(diary -> !diary.isDeleted()).toList().size();
-		if (diaryCount == 50) {
-			return getBadge(5L);
-		} else if (diaryCount == 30) {
-			return getBadge(4L);
-		} else if (diaryCount == 10) {
-			return getBadge(3L);
-		} else if (diaryCount == 1) {
-			return getBadge(2L);
-		}
-		return null;
-	}
+    private Badge getCountingDiaryBadge(Member member) {
+        int diaryCount = member.getDiaries().stream().filter(diary -> !diary.isDeleted()).toList().size();
+        if (diaryCount == 50) {
+            return getBadge(5L);
+        } else if (diaryCount == 30) {
+            return getBadge(4L);
+        } else if (diaryCount == 10) {
+            return getBadge(3L);
+        } else if (diaryCount == 1) {
+            return getBadge(2L);
+        }
+        return null;
+    }
 
-	private Badge getBadge(Long id) {
-		return badgeRepository.findById(id)
-			.orElseThrow(() -> new EntityNotFoundException(INVALID_BADGE.getMessage()));
-	}
+    private Badge getBadge(Long id) {
+        return badgeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(INVALID_BADGE.getMessage()));
+    }
 }

--- a/src/main/java/com/smeme/server/service/GoalService.java
+++ b/src/main/java/com/smeme/server/service/GoalService.java
@@ -21,16 +21,16 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class GoalService {
 
-	private final GoalRepository goalRepository;
+    private final GoalRepository goalRepository;
 
-	public GoalsResponseDTO getAllGoals() {
-		List<GoalType> goalTypes = List.of(GoalType.values());
-		return GoalsResponseDTO.of(goalTypes);
-	}
+    public GoalsResponseDTO getAllGoals() {
+        List<GoalType> goalTypes = List.of(GoalType.values());
+        return GoalsResponseDTO.of(goalTypes);
+    }
 
-	public GoalResponseDTO getGoalByType(GoalType goalType) {
-		Goal goal = goalRepository.findOneByType(goalType)
-			.orElseThrow(() -> new EntityNotFoundException(EMPTY_GOAL.getMessage()));
-		return new GoalResponseDTO(goalType.getDescription(), goal.getWay(), goal.getDetail());
-	}
+    public GoalResponseDTO getGoalByType(GoalType goalType) {
+        Goal goal = goalRepository.findOneByType(goalType)
+                .orElseThrow(() -> new EntityNotFoundException(EMPTY_GOAL.getMessage()));
+        return new GoalResponseDTO(goalType.getDescription(), goal.getWay(), goal.getDetail());
+    }
 }

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.smeme.server.service;
 
+import com.smeme.server.config.ValueConfig;
 import com.smeme.server.dto.badge.BadgeResponseDTO;
 import com.smeme.server.dto.member.*;
 import com.smeme.server.dto.training.TrainingTimeResponseDTO;
@@ -19,7 +20,6 @@ import com.smeme.server.util.message.ErrorMessage;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -37,14 +37,12 @@ import static java.util.Objects.nonNull;
 @RequiredArgsConstructor
 public class MemberService {
 
-    @Value("${badge.welcome-badge-id}")
-    private Long WELCOME_BADGE_ID;
-
     private final MemberRepository memberRepository;
     private final TrainingTimeRepository trainingTimeRepository;
     private final MemberBadgeRepository memberBadgeRepository;
     private final GoalRepository goalRepository;
     private final BadgeRepository badgeRepository;
+    private final ValueConfig valueConfig;
 
     @Transactional
     public MemberUpdateResponseDTO updateMember(Long memberId, MemberUpdateRequestDTO dto) {
@@ -57,7 +55,7 @@ public class MemberService {
 
         ArrayList<Badge> badges = new ArrayList<>();
         if (isNull(member.getUsername())) {
-            Badge welcomeBadge = getBadgeById(WELCOME_BADGE_ID);
+            Badge welcomeBadge = getBadgeById(valueConfig.getWELCOME_BADGE_ID());
             memberBadgeRepository.save(new MemberBadge(member, welcomeBadge));
             badges.add(welcomeBadge);
         }

--- a/src/main/java/com/smeme/server/service/MemberService.java
+++ b/src/main/java/com/smeme/server/service/MemberService.java
@@ -45,12 +45,12 @@ public class MemberService {
     private final ValueConfig valueConfig;
 
     @Transactional
-    public MemberUpdateResponseDTO updateMember(Long memberId, MemberUpdateRequestDTO dto) {
-        checkMemberDuplicate(dto.username());
+    public MemberUpdateResponseDTO updateMember(Long memberId, MemberUpdateRequestDTO request) {
+        checkMemberDuplicate(request.username());
         Member member = getMemberById(memberId);
 
-        if (nonNull(dto.termAccepted())) {
-            member.updateTermAccepted(dto.termAccepted());
+        if (nonNull(request.termAccepted())) {
+            member.updateTermAccepted(request.termAccepted());
         }
 
         ArrayList<Badge> badges = new ArrayList<>();
@@ -59,7 +59,7 @@ public class MemberService {
             memberBadgeRepository.save(new MemberBadge(member, welcomeBadge));
             badges.add(welcomeBadge);
         }
-        member.updateUsername(dto.username());
+        member.updateUsername(request.username());
         return MemberUpdateResponseDTO.of(badges);
     }
 
@@ -89,26 +89,26 @@ public class MemberService {
 
 
     @Transactional
-    public void updateMemberPlan(Long memberId, MemberPlanUpdateRequestDTO requestDTO) {
+    public void updateMemberPlan(Long memberId, MemberPlanUpdateRequestDTO request) {
         Member member = getMemberById(memberId);
 
-        if (nonNull(requestDTO.target())) {
-            member.updateGoal(requestDTO.target());
+        if (nonNull(request.target())) {
+            member.updateGoal(request.target());
         }
 
-        if (nonNull(requestDTO.hasAlarm())) {
-            member.updateHasAlarm(requestDTO.hasAlarm());
+        if (nonNull(request.hasAlarm())) {
+            member.updateHasAlarm(request.hasAlarm());
         }
 
-        if (nonNull(requestDTO.trainingTime()) && StringUtils.hasText(requestDTO.trainingTime().day())) {
-            updateMemberTrainingTime(member, requestDTO);
+        if (nonNull(request.trainingTime()) && StringUtils.hasText(request.trainingTime().day())) {
+            updateMemberTrainingTime(member, request);
         }
     }
 
     @Transactional
-    public void updateMemberPush(Long memberId, MemberPushUpdateRequestDTO requestDTO) {
+    public void updateMemberPush(Long memberId, MemberPushUpdateRequestDTO request) {
         Member member = getMemberById(memberId);
-        member.updateHasAlarm(requestDTO.hasAlarm());
+        member.updateHasAlarm(request.hasAlarm());
     }
 
     public MemberNameResponseDTO checkDuplicatedName(String name) {
@@ -116,13 +116,13 @@ public class MemberService {
         return new MemberNameResponseDTO(isExist);
     }
 
-    private void updateMemberTrainingTime(Member member, MemberPlanUpdateRequestDTO requestDTO) {
+    private void updateMemberTrainingTime(Member member, MemberPlanUpdateRequestDTO request) {
         trainingTimeRepository.deleteAll(member.getTrainingTimes());
-        for (String day : parseDay(requestDTO.trainingTime().day())) {
+        for (String day : parseDay(request.trainingTime().day())) {
             TrainingTime trainingTime = TrainingTime.builder()
                     .day(DayType.valueOf(day))
-                    .hour(requestDTO.trainingTime().hour())
-                    .minute(requestDTO.trainingTime().minute())
+                    .hour(request.trainingTime().hour())
+                    .minute(request.trainingTime().minute())
                     .member(member)
                     .build();
             trainingTimeRepository.save(trainingTime);

--- a/src/main/java/com/smeme/server/service/TopicService.java
+++ b/src/main/java/com/smeme/server/service/TopicService.java
@@ -14,10 +14,10 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class TopicService {
 
-	private final TopicRepository topicRepository;
+    private final TopicRepository topicRepository;
 
-	public TopicResponseDTO getRandomTopic() {
-		Topic topic = topicRepository.getRandomTopic();
-		return TopicResponseDTO.of(topic);
-	}
+    public TopicResponseDTO getRandomTopic() {
+        Topic topic = topicRepository.getRandomTopic();
+        return TopicResponseDTO.of(topic);
+    }
 }

--- a/src/main/java/com/smeme/server/service/auth/AppleSignInService.java
+++ b/src/main/java/com/smeme/server/service/auth/AppleSignInService.java
@@ -1,10 +1,10 @@
 package com.smeme.server.service.auth;
 
 import com.google.gson.*;
+import com.smeme.server.config.ValueConfig;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
@@ -25,13 +25,11 @@ import java.util.Objects;
 @Service
 public class AppleSignInService {
 
-    @Value("${jwt.APPLE_URL}")
-    private String APPLE_URL;
-
+    private final ValueConfig valueConfig;
 
     protected JsonArray getApplePublicKeyList() {
         try {
-            URL url = new URL(APPLE_URL);
+            URL url = new URL(valueConfig.getAPPLE_URL());
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
             BufferedReader br = new BufferedReader(new InputStreamReader(connection.getInputStream()));
@@ -81,8 +79,8 @@ public class AppleSignInService {
         String nStr = object.get("n").toString();
         String eStr = object.get("e").toString();
 
-        byte[] nBytes = Base64.getUrlDecoder().decode(nStr.substring(1, nStr.length() -1));
-        byte[] eBytes = Base64.getUrlDecoder().decode(eStr.substring(1, eStr.length() -1));
+        byte[] nBytes = Base64.getUrlDecoder().decode(nStr.substring(1, nStr.length() - 1));
+        byte[] eBytes = Base64.getUrlDecoder().decode(eStr.substring(1, eStr.length() - 1));
 
         BigInteger nValue = new BigInteger(1, nBytes);
         BigInteger eValue = new BigInteger(1, eBytes);
@@ -93,16 +91,16 @@ public class AppleSignInService {
     }
 
     protected String getAppleData(String socialAccessToken) throws NoSuchAlgorithmException, InvalidKeySpecException {
-            JsonArray publicKeyList = getApplePublicKeyList();
-            PublicKey publicKey = makePublicKey(socialAccessToken, publicKeyList);
+        JsonArray publicKeyList = getApplePublicKeyList();
+        PublicKey publicKey = makePublicKey(socialAccessToken, publicKeyList);
 
-            Claims userInfo = Jwts.parserBuilder()
-                    .setSigningKey(publicKey)
-                    .build()
-                    .parseClaimsJws(socialAccessToken.substring(7))
-                    .getBody();
+        Claims userInfo = Jwts.parserBuilder()
+                .setSigningKey(publicKey)
+                .build()
+                .parseClaimsJws(socialAccessToken.substring(7))
+                .getBody();
 
-            JsonObject userInfoObject = (JsonObject) JsonParser.parseString(new Gson().toJson(userInfo));
-            return userInfoObject.get("sub").getAsString();
-        }
+        JsonObject userInfoObject = (JsonObject) JsonParser.parseString(new Gson().toJson(userInfo));
+        return userInfoObject.get("sub").getAsString();
+    }
 }

--- a/src/main/java/com/smeme/server/service/auth/AuthService.java
+++ b/src/main/java/com/smeme/server/service/auth/AuthService.java
@@ -49,9 +49,9 @@ public class AuthService {
     private final CorrectionRepository correctionRepository;
 
     @Transactional
-    public SignInResponseDTO signIn(String socialAccessToken, SignInRequestDTO signInRequestDTO) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    public SignInResponseDTO signIn(String socialAccessToken, SignInRequestDTO request) throws NoSuchAlgorithmException, InvalidKeySpecException {
 
-        SocialType socialType = signInRequestDTO.socialType();
+        SocialType socialType = request.socialType();
         String socialId = login(socialType, socialAccessToken);
 
         boolean hasMember = isMemberBySocialAndSocialId(socialType, socialId);
@@ -61,7 +61,7 @@ public class AuthService {
                     .social(socialType)
                     .socialId(socialId)
                     .targetLang(LangType.en)
-                    .fcmToken(signInRequestDTO.fcmToken())
+                    .fcmToken(request.fcmToken())
                     .build();
             memberRepository.save(member);
         }

--- a/src/main/java/com/smeme/server/service/auth/BetaAuthService.java
+++ b/src/main/java/com/smeme/server/service/auth/BetaAuthService.java
@@ -40,14 +40,14 @@ public class BetaAuthService {
     private static final Long BETA_USER_EXPIRED = 60 * 60 * 1000 * 24 * 21L;
 
     @Transactional
-    public BetaTokenResponseDTO createBetaMember(BetaSignInRequestDTO requestDTO) {
+    public BetaTokenResponseDTO createBetaMember(BetaSignInRequestDTO request) {
 
         AtomicInteger atomicInteger = new AtomicInteger(1);
         Member betaMember = Member.builder()
                 .social(BETA)
                 .targetLang(en)
                 .socialId("beta" + atomicInteger.getAndIncrement())
-                .fcmToken(requestDTO.fcmToken())
+                .fcmToken(request.fcmToken())
                 .build();
         memberRepository.save(betaMember);
         Authentication authentication = new UserAuthentication(betaMember.getId(), null, null);

--- a/src/main/java/com/smeme/server/service/auth/BetaAuthService.java
+++ b/src/main/java/com/smeme/server/service/auth/BetaAuthService.java
@@ -1,5 +1,6 @@
 package com.smeme.server.service.auth;
 
+import com.smeme.server.config.ValueConfig;
 import com.smeme.server.config.jwt.JwtTokenProvider;
 import com.smeme.server.config.jwt.UserAuthentication;
 import com.smeme.server.dto.auth.beta.BetaSignInRequestDTO;
@@ -14,7 +15,6 @@ import com.smeme.server.repository.badge.MemberBadgeRepository;
 import com.smeme.server.util.message.ErrorMessage;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,9 +35,8 @@ public class BetaAuthService {
     private final MemberBadgeRepository memberBadgeRepository;
     private final JwtTokenProvider tokenProvider;
     private final BadgeRepository badgeRepository;
+    private final ValueConfig valueConfig;
 
-    @Value("${badge.welcome-badge-id}")
-    private Long WELCOME_BADGE_ID;
     private static final Long BETA_USER_EXPIRED = 60 * 60 * 1000 * 24 * 21L;
 
     @Transactional
@@ -58,7 +57,7 @@ public class BetaAuthService {
     }
 
     private Badge addWelcomeBadge(Member member) {
-        Badge badge = badgeRepository.findById(WELCOME_BADGE_ID).orElseThrow(
+        Badge badge = badgeRepository.findById(valueConfig.getWELCOME_BADGE_ID()).orElseThrow(
                 () -> new EntityNotFoundException(ErrorMessage.EMPTY_BADGE.getMessage())
         );
         memberBadgeRepository.save(new MemberBadge(member, badge));

--- a/src/main/java/com/smeme/server/service/auth/KakaoSignInService.java
+++ b/src/main/java/com/smeme/server/service/auth/KakaoSignInService.java
@@ -2,6 +2,7 @@ package com.smeme.server.service.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.JsonArray;
+import com.smeme.server.config.ValueConfig;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -16,15 +17,14 @@ import java.util.Map;
 @Service
 public class KakaoSignInService {
 
-    @Value("${jwt.KAKAO_URL}")
-    private String KAKAO_URL;
+    private final ValueConfig valueConfig;
 
     protected String getKakaoData(String accessToken) {
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", accessToken);
         HttpEntity<JsonArray> httpEntity = new HttpEntity<>(headers);
-        ResponseEntity<Object> responseData = restTemplate.postForEntity(KAKAO_URL, httpEntity, Object.class);
+        ResponseEntity<Object> responseData = restTemplate.postForEntity(valueConfig.getKAKAO_URL(), httpEntity, Object.class);
         ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.convertValue(responseData.getBody(), Map.class).get("id").toString();
     }

--- a/src/main/java/com/smeme/server/util/ApiResponse.java
+++ b/src/main/java/com/smeme/server/util/ApiResponse.java
@@ -7,36 +7,34 @@ import lombok.NonNull;
 @Schema(description = "API 요청 응답 DTO")
 @Builder
 public record ApiResponse(
-	@Schema(description = "성공 여부")
-	boolean success,
-
-	@Schema(description = "응답 메세지")
-	@NonNull
-	String message,
-
-	@Schema(description = " 응답 데이터 || Null")
-	Object data
+        @Schema(description = "성공 여부")
+        boolean success,
+        @Schema(description = "응답 메세지")
+        @NonNull
+        String message,
+        @Schema(description = " 응답 데이터 || Null")
+        Object data
 ) {
 
     public static ApiResponse success(String message, Object data) {
         return ApiResponse.builder()
-            .success(true)
-            .message(message)
-            .data(data)
-            .build();
+                .success(true)
+                .message(message)
+                .data(data)
+                .build();
     }
 
     public static ApiResponse success(String message) {
         return ApiResponse.builder()
-            .success(true)
-            .message(message)
-            .build();
+                .success(true)
+                .message(message)
+                .build();
     }
 
     public static ApiResponse fail(String message) {
         return ApiResponse.builder()
-            .success(false)
-            .message(message)
-            .build();
+                .success(false)
+                .message(message)
+                .build();
     }
 }

--- a/src/main/java/com/smeme/server/util/Util.java
+++ b/src/main/java/com/smeme/server/util/Util.java
@@ -12,22 +12,22 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 public class Util {
 
-	public static Long getMemberId(Principal principal) {
-		if (isNull(principal)) {
-			throw new SecurityException(EMPTY_ACCESS_TOKEN.getMessage());
-		}
-		return Long.valueOf(principal.getName());
-	}
+    public static Long getMemberId(Principal principal) {
+        if (isNull(principal)) {
+            throw new SecurityException(EMPTY_ACCESS_TOKEN.getMessage());
+        }
+        return Long.valueOf(principal.getName());
+    }
 
-	public static String transferDateTimeToString(LocalDateTime dateTime) {
-		return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
-	}
+    public static String transferDateTimeToString(LocalDateTime dateTime) {
+        return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+    }
 
-	public static URI getURI(Long diaryId) {
-		return ServletUriComponentsBuilder
-			.fromCurrentRequest()
-			.path("/{diaryId}")
-			.buildAndExpand(diaryId)
-			.toUri();
-	}
+    public static URI getURI(Long diaryId) {
+        return ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{diaryId}")
+                .buildAndExpand(diaryId)
+                .toUri();
+    }
 }

--- a/src/main/java/com/smeme/server/util/message/ErrorMessage.java
+++ b/src/main/java/com/smeme/server/util/message/ErrorMessage.java
@@ -7,41 +7,40 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorMessage {
 
-	// auth
-	EMPTY_ACCESS_TOKEN("액세스 토큰이 없습니다."),
-	EMPTY_REFRESH_TOKEN("리프레시 토큰이 없습니다"),
-	INVALID_TOKEN("유효하지 않은 토큰입니다"),
-	MESSAGE_UNAUTHORIZED("유효하지 않은 토큰"),
+    // auth
+    EMPTY_ACCESS_TOKEN("액세스 토큰이 없습니다."),
+    EMPTY_REFRESH_TOKEN("리프레시 토큰이 없습니다"),
+    INVALID_TOKEN("유효하지 않은 토큰입니다"),
+    MESSAGE_UNAUTHORIZED("유효하지 않은 토큰"),
 
-	// member
-	EMPTY_MEMBER("존재하지 않는 회원입니다."),
-	DUPLICATE_USERNAME("이미 존재하는 닉네임입니다."),
-	INVALID_MEMBER("유효하지 않은 회원입니다."),
-	INVALID_USERNAME("유효하지 않은 닉네임입니다."),
+    // member
+    EMPTY_MEMBER("존재하지 않는 회원입니다."),
+    DUPLICATE_USERNAME("이미 존재하는 닉네임입니다."),
+    INVALID_MEMBER("유효하지 않은 회원입니다."),
+    INVALID_USERNAME("유효하지 않은 닉네임입니다."),
 
-	// diary
-	EXIST_TODAY_DIARY("일기는 하루에 한 번씩 작성할 수 있습니다."),
-	INVALID_DIARY("유효하지 않은 일기입니다."),
-	DELETED_DIARY("삭제된 일기입니다."),
+    // diary
+    EXIST_TODAY_DIARY("일기는 하루에 한 번씩 작성할 수 있습니다."),
+    INVALID_DIARY("유효하지 않은 일기입니다."),
+    DELETED_DIARY("삭제된 일기입니다."),
 
-	// correction
-	INVALID_CORRECTION("유효하지 않은 첨삭입니다."),
+    // correction
+    INVALID_CORRECTION("유효하지 않은 첨삭입니다."),
 
-	// topic
-	INVALID_TOPIC("유효하지 않은 랜덤주제입니다."),
+    // topic
+    INVALID_TOPIC("유효하지 않은 랜덤주제입니다."),
 
-	// Push Alarm
-	INVALID_DAY_OF_WEEK("유효하지 않은 요일 값입니다."),
+    // Push Alarm
+    INVALID_DAY_OF_WEEK("유효하지 않은 요일 값입니다."),
 
-	// Training Time
-	EMPTY_TRAINING_TIME("존재하지 않는 학습계획 입니다."),
-	// badge
-	INVALID_BADGE("유효하지 않은 뱃지입니다."),
-	EMPTY_BADGE("존재하지 않는 뱃지입니다."),
+    // Training Time
+    EMPTY_TRAINING_TIME("존재하지 않는 학습계획 입니다."),
+    // badge
+    INVALID_BADGE("유효하지 않은 뱃지입니다."),
+    EMPTY_BADGE("존재하지 않는 뱃지입니다."),
 
-	// goal
-	EMPTY_GOAL("존재하지 않는 목표입니다.")
-	;
+    // goal
+    EMPTY_GOAL("존재하지 않는 목표입니다.");
 
-	private final String message;
+    private final String message;
 }

--- a/src/main/java/com/smeme/server/util/message/ResponseMessage.java
+++ b/src/main/java/com/smeme/server/util/message/ResponseMessage.java
@@ -6,49 +6,48 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum ResponseMessage {
-	// diary
-	SUCCESS_CREATE_DIARY("일기 생성 성공"),
-	SUCCESS_GET_DIARY("일기 상세 조회 성공"),
-	SUCCESS_UPDATE_DAIRY("일기 수정 성공"),
-	SUCCESS_DELETE_DIARY("일기 삭제 성공"),
-	SUCCESS_GET_DIARIES("일기 리스트 조회 성공"),
+    // diary
+    SUCCESS_CREATE_DIARY("일기 생성 성공"),
+    SUCCESS_GET_DIARY("일기 상세 조회 성공"),
+    SUCCESS_UPDATE_DAIRY("일기 수정 성공"),
+    SUCCESS_DELETE_DIARY("일기 삭제 성공"),
+    SUCCESS_GET_DIARIES("일기 리스트 조회 성공"),
 
-	// topic
-	SUCCESS_GET_RANDOM_TOPIC("랜덤 주제 조회 성공"),
+    // topic
+    SUCCESS_GET_RANDOM_TOPIC("랜덤 주제 조회 성공"),
 
-	// badges
-	SUCCESS_GET_BADGES("뱃지 리스트 조회 성공"),
+    // badges
+    SUCCESS_GET_BADGES("뱃지 리스트 조회 성공"),
 
-	// correction
-	SUCCESS_CREATE_CORRECTION("일기 첨삭 성공"),
-	SUCCESS_DELETE_CORRECTION("첨삭 삭제 성공"),
-	SUCCESS_UPDATE_CORRECTION("첨삭 수정 성공"),
+    // correction
+    SUCCESS_CREATE_CORRECTION("일기 첨삭 성공"),
+    SUCCESS_DELETE_CORRECTION("첨삭 삭제 성공"),
+    SUCCESS_UPDATE_CORRECTION("첨삭 수정 성공"),
 
-	// member
-	SUCCESS_UPDATE_USERNAME("닉네임 변경 성공"),
-	SUCCESS_GET_USER("회원 정보 조회 성공"),
-	SUCCESS_UPDATE_USER_PLAN("회원 학습 계획 업데이트 성공"),
-	SUCCESS_CHECK_DUPLICATED_NAME("닉네임 중복 검사 성공"),
-	SUCCESS_UPDATE_USER_PUSH("회원 푸시알람 동의여부 업데이트 성공"),
+    // member
+    SUCCESS_UPDATE_USERNAME("닉네임 변경 성공"),
+    SUCCESS_GET_USER("회원 정보 조회 성공"),
+    SUCCESS_UPDATE_USER_PLAN("회원 학습 계획 업데이트 성공"),
+    SUCCESS_CHECK_DUPLICATED_NAME("닉네임 중복 검사 성공"),
+    SUCCESS_UPDATE_USER_PUSH("회원 푸시알람 동의여부 업데이트 성공"),
 
-	// message
-	SUCCESS_PUSH_MESSAGE("푸시알람 요청 성공"),
+    // message
+    SUCCESS_PUSH_MESSAGE("푸시알람 요청 성공"),
 
-	// oauth
-	SUCCESS_SIGNIN("소셜로그인 성공"),
-	SUCCESS_SIGNOUT("로그아웃 성공"),
-	SUCCESS_WITHDRAW("회원 탈퇴 성공"),
+    // oauth
+    SUCCESS_SIGNIN("소셜로그인 성공"),
+    SUCCESS_SIGNOUT("로그아웃 성공"),
+    SUCCESS_WITHDRAW("회원 탈퇴 성공"),
 
-	// jwt
-	SUCCESS_ISSUE_TOKEN("토큰 발급 성공"),
+    // jwt
+    SUCCESS_ISSUE_TOKEN("토큰 발급 성공"),
 
-	// beta
-	SUCCESS_BETA_AUTH_TOKEN("임시토큰 발급 성공"),
+    // beta
+    SUCCESS_BETA_AUTH_TOKEN("임시토큰 발급 성공"),
 
-	// goal
-	SUCCESS_GET_GOALS("학습 목표 리스트 조회 성공"),
-	SUCCESS_GET_GOAL("학습 목표 조회 성공")
-	;
+    // goal
+    SUCCESS_GET_GOALS("학습 목표 리스트 조회 성공"),
+    SUCCESS_GET_GOAL("학습 목표 조회 성공");
 
-	private final String message;
+    private final String message;
 }


### PR DESCRIPTION

## Related issue 🚀
- closed #146 

## Work Description 💚
- 전체 코드의 컨벤션을 통일했습니다.
- 인텔리제이 Settings > Code Style > Java > Tabs and Indents 설정
  ![image](https://github.com/Team-Smeme/Smeme-server-renewal/assets/55437339/9e1368a6-f219-4c2c-a445-43d5d7de4349)
- 위 설정을 기반으로 전체적으로 인텔리제이 코드 교정 기능을 실행했습니다.(option+command+L, macOS 기준)
- 삼항연산자가 가능한 if문은 삼항연산자 처리했습니다.
- final 변수는 Lombok의 val 기능을 사용했습니다.
- ValueConfig 파일을 추가하여 `@Value` 값을 한 곳에 정리했습니다.
- static 변수가 가능한 값은 static import 처리했습니다.(ENUM 값, 인자로 들어가는 값 기준)
- 클래스명에서 한 줄 띄어쓰기 후 코드가 시작되도록 통일했습니다.
- 메소드는 public > private 순으로 배치 통일했습니다.
- DTO 파일 형식을 통일했습니다. (Ex. public record 내 record 배치 등)
- 미사용 메서드 및 파일은 삭제했습니다.
- 변경한 부분의 이유는 가독성 및 통일성입니다. 의도하여 지정한 코드가 변경된 부분이 있다면 말씀해주세요! 변경 전으로 되돌려놓겠습니다 :)
- 그 외 피드백이 있다면 리뷰로 남겨주세요. 감사합니다 :)