### PR TITLE
[FIX] 회원이 임시 삭제한 일기 데이터 삭제

### DIFF
--- a/src/main/java/com/smeme/server/repository/diary/DeletedDiaryRepository.java
+++ b/src/main/java/com/smeme/server/repository/diary/DeletedDiaryRepository.java
@@ -1,10 +1,12 @@
 package com.smeme.server.repository.diary;
 
 import com.smeme.server.model.DeletedDiary;
+import com.smeme.server.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 
 public interface DeletedDiaryRepository extends JpaRepository<DeletedDiary, Long> {
     void deleteByUpdatedAtBefore(LocalDateTime expiredAt);
+    void deleteByMember(Member member);
 }

--- a/src/main/java/com/smeme/server/service/DiaryService.java
+++ b/src/main/java/com/smeme/server/service/DiaryService.java
@@ -112,6 +112,7 @@ public class DiaryService {
     @Transactional
     public void deleteAllByMember(Member member) {
         diaryRepository.deleteAllByMember(member);
+        deletedDiaryRepository.deleteByMember(member);
     }
 
     public List<Diary> getAllByMemberId(Long memberId) {


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #194 

## Work Description 💚
- 회원탈퇴 관련 500 에러 대응
- 회원이 임시 삭제한 일기 데이터를 추가로 삭제하도록 했습니다.


<img width="1029" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/55437339/9dccd362-10a6-4748-a780-dab7f60f3b3d">
