### PR TITLE
[FIX] Bearer 중복으로 들어가는 코드 삭제

### DIFF
--- a/smeem-external/src/main/java/com/smeem/external/oauth/kakao/KakaoService.java
+++ b/smeem-external/src/main/java/com/smeem/external/oauth/kakao/KakaoService.java
@@ -22,7 +22,7 @@ public class KakaoService {
             val restClient = RestClient.create();
             val response = restClient.get()
                     .uri(valueConfig.getKAKAO_URL())
-                    .header(AUTHORIZATION, "Bearer " + accessToken)
+                    .header(AUTHORIZATION, accessToken)
                     .retrieve()
                     .onStatus(HttpStatusCode::is4xxClientError,
                             (kakaoRequest, kakaoResponse) -> {


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #214 

## Work Description 💚
- Bearer String이 중복으로 들어가, 카카오 로그인에 실패하여 카카오 로그인이 실패하는 버그를 해결했습니다. 


##  Test
- TestCode에 대해서는 논의가 안되어 있어, 우선 Postman 으로 API Test 진행했습니다!
<img width="1046" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/81692211/3f5ffa4d-c531-4c02-b5a0-d96f1c385e91">
