### PR TITLE
[FIX] 학습 계획 설정 API 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.2.0'
+    id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 

--- a/smeem-api/src/main/java/com/smeem/api/common/advicer/ErrorHandler.java
+++ b/smeem-api/src/main/java/com/smeem/api/common/advicer/ErrorHandler.java
@@ -2,8 +2,6 @@ package com.smeem.api.common.advicer;
 
 import com.smeem.api.common.ApiResponseUtil;
 import com.smeem.api.common.BaseResponse;
-import com.smeem.common.code.failure.FailureCode;
-import com.smeem.common.code.failure.InternalServerFailureCode;
 import com.smeem.common.exception.*;
 import com.smeem.external.discord.DiscordAlarmSender;
 import lombok.RequiredArgsConstructor;

--- a/smeem-api/src/main/java/com/smeem/api/member/controller/dto/request/TrainingTimeRequest.java
+++ b/smeem-api/src/main/java/com/smeem/api/member/controller/dto/request/TrainingTimeRequest.java
@@ -1,13 +1,9 @@
 package com.smeem.api.member.controller.dto.request;
 
-import jakarta.validation.constraints.NotNull;
 
 public record TrainingTimeRequest(
-        @NotNull
         String day,
-        @NotNull
-        int hour,
-        @NotNull
-        int minute
+        Integer hour,
+        Integer minute
 ) {
 }

--- a/smeem-api/src/main/java/com/smeem/api/member/service/MemberService.java
+++ b/smeem-api/src/main/java/com/smeem/api/member/service/MemberService.java
@@ -93,7 +93,6 @@ public class MemberService {
     public void updateLearningPlan(final long memberId, final MemberUpdatePlanServiceRequest request) {
         val member = get(memberId);
         member.updateGoal(request.goalType());
-        member.updateGoal(request.goalType());
         member.updateHasAlarm(request.hasAlarm());
         updateTrainingTime(member, request.trainingTime());
     }

--- a/smeem-api/src/main/java/com/smeem/api/member/service/dto/request/TrainingTimeServiceRequest.java
+++ b/smeem-api/src/main/java/com/smeem/api/member/service/dto/request/TrainingTimeServiceRequest.java
@@ -9,10 +9,13 @@ import static lombok.AccessLevel.PRIVATE;
 @Builder(access = PRIVATE)
 public record TrainingTimeServiceRequest(
         String day,
-        int hour,
-        int minute
+        Integer hour,
+        Integer minute
 ) {
     public static TrainingTimeServiceRequest of(TrainingTimeRequest request) {
+        if (request == null) {
+            return null;
+        }
         return TrainingTimeServiceRequest.builder()
                 .day(request.day())
                 .hour(request.hour())


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #224 

## Work Description 💚
- 현재 학습 계획 설정 API에서, 스펙상으로는 TrainingTimeRequest를 null로 보낼 수 있지만 nullable하지 않아, 요청시에 오류가 발생하고 있습니다. 해당 부분을 수정했어요~
- 관련 노션 API 명세서에는 댓글로 언급 해두겠습니다.
- 로직 자체가 Null - Safety가 많이 떨어지는 것 같아서, 수정 방향도 고려해보면 좋겠네요 ~~

### 스크린샷
- 각각 요청 보내는 상황에 대해서 모두 성공하는지 test해봤습니다..>!
<img width="627" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/81692211/3bce5b0e-c5c1-401e-9d29-54ef8b201119">
<img width="693" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/81692211/8a75deed-1eb4-4392-85d0-f131f1459128">
<img width="546" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/81692211/4d15c58d-3a21-4f6b-8127-a2fe6ab11ed6">
