### PR TITLE
[FEAT] 클라이언트 앱 버전 조회 API

### DIFF
--- a/smeem-api/src/main/java/com/smeem/api/config/SecurityConfig.java
+++ b/smeem-api/src/main/java/com/smeem/api/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
                         authorizeHttpRequests
                                 .requestMatchers(new AntPathRequestMatcher("/api/v2/auth", "POST")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/api/v2/test")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/api/v2/versions/client/app")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/api/v2/goals/{type}")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/api/v2/goals")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/api/v2/members/nickname/check")).permitAll()

--- a/smeem-api/src/main/java/com/smeem/api/version/api/VersionApi.java
+++ b/smeem-api/src/main/java/com/smeem/api/version/api/VersionApi.java
@@ -1,0 +1,19 @@
+package com.smeem.api.version.api;
+
+import com.smeem.api.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "[Version] 버 관련 API (V2)")
+public interface VersionApi {
+
+    @Operation(summary = "클라이언트 앱 버전 조회 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    ResponseEntity<BaseResponse<?>> getClientVersion();
+}

--- a/smeem-api/src/main/java/com/smeem/api/version/api/VersionApiController.java
+++ b/smeem-api/src/main/java/com/smeem/api/version/api/VersionApiController.java
@@ -1,0 +1,28 @@
+package com.smeem.api.version.api;
+
+import com.smeem.api.common.ApiResponseUtil;
+import com.smeem.api.common.BaseResponse;
+import com.smeem.api.version.api.dto.response.ClientVersionGetResponse;
+import com.smeem.api.version.service.VersionService;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.smeem.common.code.success.VersionSuccessCode.SUCCESS_GET_APP_VERSION;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/versions")
+public class VersionApiController implements VersionApi {
+
+    private final VersionService versionService;
+
+    @GetMapping("/client/app")
+    public ResponseEntity<BaseResponse<?>> getClientVersion() {
+        val response = ClientVersionGetResponse.of(versionService.getClientVersion());
+        return ApiResponseUtil.success(SUCCESS_GET_APP_VERSION, response);
+    }
+}

--- a/smeem-api/src/main/java/com/smeem/api/version/api/dto/response/ClientVersionGetResponse.java
+++ b/smeem-api/src/main/java/com/smeem/api/version/api/dto/response/ClientVersionGetResponse.java
@@ -1,0 +1,36 @@
+package com.smeem.api.version.api.dto.response;
+
+import com.smeem.api.version.service.dto.response.ClientVersionGetServiceResponse;
+import lombok.Builder;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
+public record ClientVersionGetResponse(
+        String title,
+        String content,
+        VersionResponse iosVersion
+) {
+
+    public static ClientVersionGetResponse of(ClientVersionGetServiceResponse response) {
+        return ClientVersionGetResponse.builder()
+                .title(response.title())
+                .content(response.content())
+                .iosVersion(VersionResponse.of(response.iosVersion(), response.iosForceVersion()))
+                .build();
+    }
+
+    @Builder(access = PRIVATE)
+    private record VersionResponse(
+            String version,
+            String forceVersion
+    ) {
+
+        private static VersionResponse of(String version, String forceVersion) {
+            return VersionResponse.builder()
+                    .version(version)
+                    .forceVersion(forceVersion)
+                    .build();
+        }
+    }
+}

--- a/smeem-api/src/main/java/com/smeem/api/version/service/VersionService.java
+++ b/smeem-api/src/main/java/com/smeem/api/version/service/VersionService.java
@@ -1,0 +1,19 @@
+package com.smeem.api.version.service;
+
+import com.smeem.api.version.service.dto.response.ClientVersionGetServiceResponse;
+import com.smeem.common.config.ValueConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VersionService {
+
+    private final ValueConfig valueConfig;
+
+    public ClientVersionGetServiceResponse getClientVersion() {
+        return ClientVersionGetServiceResponse.of(valueConfig);
+    }
+}

--- a/smeem-api/src/main/java/com/smeem/api/version/service/dto/response/ClientVersionGetServiceResponse.java
+++ b/smeem-api/src/main/java/com/smeem/api/version/service/dto/response/ClientVersionGetServiceResponse.java
@@ -1,0 +1,24 @@
+package com.smeem.api.version.service.dto.response;
+
+import com.smeem.common.config.ValueConfig;
+import lombok.Builder;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
+public record ClientVersionGetServiceResponse(
+        String title,
+        String content,
+        String iosVersion,
+        String iosForceVersion
+) {
+
+    public static ClientVersionGetServiceResponse of(ValueConfig valueConfig) {
+        return ClientVersionGetServiceResponse.builder()
+                .title(valueConfig.getCLIENT_VERSION_UPDATE_TITLE())
+                .content(valueConfig.getCLIENT_VERSION_UPDATE_CONTENT())
+                .iosVersion(valueConfig.getCLIENT_VERSION_IOS_VERSION())
+                .iosForceVersion(valueConfig.getCLIENT_VERSION_IOS_FORCE_VERSION())
+                .build();
+    }
+}

--- a/smeem-api/src/main/resources/application-dev.yml
+++ b/smeem-api/src/main/resources/application-dev.yml
@@ -42,6 +42,13 @@ smeem:
   duration:
     expired: ${SMEEM.DURATION.EXPIRED}
     remind: ${SMEEM.DURATION.REMIND}
+  client:
+    version:
+      title: "업데이트 알림"
+      content: "보다 나아진 스밈의 최신 버전을 준비했어요! 새로운 버전으로 업데이트 후 이용해주세요."
+      ios:
+        app: 2.0.0
+        force: 2.0.0
 
 discord:
     webhook:

--- a/smeem-api/src/main/resources/application-prod.yml
+++ b/smeem-api/src/main/resources/application-prod.yml
@@ -43,6 +43,13 @@ smeem:
   duration:
     expired: ${SMEEM.DURATION.EXPIRED}
     remind: ${SMEEM.DURATION.REMIND}
+  client:
+    version:
+      title: "업데이트 알림"
+      content: "보다 나아진 스밈의 최신 버전을 준비했어요! 새로운 버전으로 업데이트 후 이용해주세요."
+      ios:
+        app: 2.0.0
+        force: 2.0.0 # 심사 통과 후 3.0.0 업데이트 필요
 
 discord:
   webhook:

--- a/smeem-common/src/main/java/com/smeem/common/code/success/VersionSuccessCode.java
+++ b/smeem-common/src/main/java/com/smeem/common/code/success/VersionSuccessCode.java
@@ -1,0 +1,21 @@
+package com.smeem.common.code.success;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@RequiredArgsConstructor
+@Getter
+public enum VersionSuccessCode implements SuccessCode {
+
+    /**
+     * 200 Ok
+     */
+    SUCCESS_GET_APP_VERSION(OK, "앱 버전 조회 성공"),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/smeem-common/src/main/java/com/smeem/common/config/ValueConfig.java
+++ b/smeem-common/src/main/java/com/smeem/common/config/ValueConfig.java
@@ -51,6 +51,18 @@ public class ValueConfig {
     @Value("${discord.webhook.info-url}")
     private String DISCORD_WEBHOOK_INFO_URL;
 
+    @Value("${smeem.client.version.title}")
+    private String CLIENT_VERSION_UPDATE_TITLE;
+
+    @Value("${smeem.client.version.content}")
+    private String CLIENT_VERSION_UPDATE_CONTENT;
+
+    @Value("${smeem.client.version.ios.app}")
+    private String CLIENT_VERSION_IOS_VERSION;
+
+    @Value("${smeem.client.version.ios.force}")
+    private String CLIENT_VERSION_IOS_FORCE_VERSION;
+
     public static final String SIGN_IN_MESSAGE = "새로운 유저가 가입했습니다! ✍️ : ";
 
     public static final boolean DEFAULT_IS_PUBLIC_VALUE = true;


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #234 

## Work Description 💚
- iOS 심사 이슈로 앱 버전 조회 API 추가했습니다. (이후 안드에게도 상황 설명 후, 서버 버전 관리 사용한다고 하면 안드 버전도 추가할 예정)
- `고민점` : Service DTO 인자 값으로 ValueConfig를 넘겼습니다. 설정 값만 사용한다는 상황으로 판단한 방식입니다. 설정 값 하나씩 인자 값으로 넣어주는 방식도 고민했는데, 어떻게 생각하시나요!?

<br/>

<img width="1010" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/55437339/a9986239-c794-4fea-95fd-0e1920548ba0">
