### PR TITLE
[FEAT] 플랜 전체 조회 API

### DIFF
--- a/smeem-api/src/main/java/com/smeem/api/config/SecurityConfig.java
+++ b/smeem-api/src/main/java/com/smeem/api/config/SecurityConfig.java
@@ -13,7 +13,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 
 
 @Configuration
@@ -54,6 +53,7 @@ public class SecurityConfig {
                                 .requestMatchers(new AntPathRequestMatcher("/api/v2/goals/{type}")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/api/v2/goals")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/api/v2/members/nickname/check")).permitAll()
+                                .requestMatchers(new AntPathRequestMatcher("/api/v2/plans")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/favicon.ico")).permitAll()
                                 .requestMatchers(new AntPathRequestMatcher("/error")).permitAll()
                                 .anyRequest().authenticated())

--- a/smeem-api/src/main/java/com/smeem/api/member/api/MemberApi.java
+++ b/smeem-api/src/main/java/com/smeem/api/member/api/MemberApi.java
@@ -91,7 +91,6 @@ public interface MemberApi {
     );
 
     @Operation(summary = "사용자 플랜 조회 API")
-    @Parameter(name = "Authorization", description = "Bearer ${Smeme Access Token}", in = HEADER, required = true)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "요청 성공"),
             @ApiResponse(

--- a/smeem-api/src/main/java/com/smeem/api/member/api/MemberApi.java
+++ b/smeem-api/src/main/java/com/smeem/api/member/api/MemberApi.java
@@ -35,8 +35,10 @@ public interface MemberApi {
             @ApiResponse(responseCode = "4xx", description = "유효하지 않은 요청", content = @Content(schema = @Schema(implementation = FailureResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content(schema = @Schema(implementation = FailureResponse.class)))
     })
-    ResponseEntity<SuccessResponse<MemberUpdateResponse>> updateProfile(Principal principal, @RequestBody MemberUpdateRequest request);
-
+    ResponseEntity<SuccessResponse<MemberUpdateResponse>> updateProfile(
+            @Parameter(hidden = true) Principal principal,
+            @RequestBody MemberUpdateRequest request
+    );
 
     @Operation(summary = "사용자 프로필 조회 API")
     @Parameter(name = "Authorization", description = "Bearer ${Smeme Access Token}", in = HEADER, required = true)
@@ -55,7 +57,7 @@ public interface MemberApi {
             @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다", content = @Content(schema = @Schema(implementation = FailureResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = FailureResponse.class)))
     })
-    ResponseEntity<SuccessResponse<?>> updateUserPlan(Principal principal, @Valid @RequestBody MemberPlanUpdateRequest request);
+    ResponseEntity<SuccessResponse<?>> updateMemberPlan(Principal principal, @Valid @RequestBody MemberPlanUpdateRequest request);
 
     @Operation(summary = "사용자 닉네임 중복체크 수정 API")
     @Parameter(name = "Authorization", description = "Bearer ${Smeme Access Token}", in = HEADER, required = true)

--- a/smeem-api/src/main/java/com/smeem/api/member/api/MemberController.java
+++ b/smeem-api/src/main/java/com/smeem/api/member/api/MemberController.java
@@ -51,7 +51,10 @@ public class MemberController implements MemberApi {
 
     @Override
     @PatchMapping("/plan")
-    public ResponseEntity<SuccessResponse<?>> updateUserPlan(Principal principal, @Valid @RequestBody MemberPlanUpdateRequest request) {
+    public ResponseEntity<SuccessResponse<?>> updateMemberPlan(
+            Principal principal,
+            @Valid @RequestBody MemberPlanUpdateRequest request
+    ) {
         val memberId = PrincipalConverter.getMemberId(principal);
         memberService.updateLearningPlan(MemberUpdatePlanServiceRequest.of(memberId, request));
         return ApiResponseGenerator.success(SUCCESS_UPDATE_USER_PLAN);

--- a/smeem-api/src/main/java/com/smeem/api/member/api/dto/request/MemberPlanUpdateRequest.java
+++ b/smeem-api/src/main/java/com/smeem/api/member/api/dto/request/MemberPlanUpdateRequest.java
@@ -6,6 +6,7 @@ import com.smeem.domain.goal.model.GoalType;
 public record MemberPlanUpdateRequest(
         GoalType target,
         TrainingTimeRequest trainingTime,
-        Boolean hasAlarm
+        Boolean hasAlarm,
+        Long planId
 ) {
 }

--- a/smeem-api/src/main/java/com/smeem/api/member/service/MemberService.java
+++ b/smeem-api/src/main/java/com/smeem/api/member/service/MemberService.java
@@ -13,6 +13,7 @@ import com.smeem.api.member.service.dto.response.*;
 import com.smeem.common.config.ValueConfig;
 import com.smeem.domain.badge.adapter.BadgeFinder;
 import com.smeem.domain.member.exception.MemberException;
+import com.smeem.domain.plan.adapter.PlanFinder;
 import com.smeem.domain.training.exception.TrainingTimeException;
 import com.smeem.domain.badge.model.Badge;
 import com.smeem.domain.member.adapter.member.MemberFinder;
@@ -46,6 +47,7 @@ public class MemberService {
     private final BadgeFinder badgeFinder;
     private final MemberFinder memberFinder;
     private final MemberUpdater memberUpdater;
+    private final PlanFinder planFinder;
 
     private final TrainingTimeService trainingTimeService;
     private final GoalService goalService;
@@ -93,6 +95,7 @@ public class MemberService {
         member.updateGoal(request.goalType());
         member.updateHasAlarm(request.hasAlarm());
         updateTrainingTime(member, request.trainingTime());
+        updatePlan(member, request.planId());
     }
 
     @Transactional
@@ -123,6 +126,13 @@ public class MemberService {
                         .build();
                 trainingTimeService.save(trainingTime);
             }
+        }
+    }
+
+    private void updatePlan(final Member member, final Long planId) {
+        if (nonNull(planId)) {
+            val plan = planFinder.findById(planId);
+            member.updatePlan(plan);
         }
     }
 

--- a/smeem-api/src/main/java/com/smeem/api/member/service/dto/request/MemberUpdatePlanServiceRequest.java
+++ b/smeem-api/src/main/java/com/smeem/api/member/service/dto/request/MemberUpdatePlanServiceRequest.java
@@ -11,14 +11,17 @@ public record MemberUpdatePlanServiceRequest(
         long memberId,
         GoalType goalType,
         TrainingTimeServiceRequest trainingTime,
-        Boolean hasAlarm
+        Boolean hasAlarm,
+        Long planId
 ) {
+
     public static MemberUpdatePlanServiceRequest of(long memberId, MemberPlanUpdateRequest request) {
         return MemberUpdatePlanServiceRequest.builder()
                 .memberId(memberId)
                 .goalType(request.target())
                 .trainingTime(TrainingTimeServiceRequest.of(request.trainingTime()))
                 .hasAlarm(request.hasAlarm())
+                .planId(request.planId())
                 .build();
     }
 }

--- a/smeem-api/src/main/java/com/smeem/api/plan/api/PlanApi.java
+++ b/smeem-api/src/main/java/com/smeem/api/plan/api/PlanApi.java
@@ -1,0 +1,32 @@
+package com.smeem.api.plan.api;
+
+import com.smeem.api.common.FailureResponse;
+import com.smeem.api.common.SuccessResponse;
+import com.smeem.api.plan.api.dto.response.PlansAllGetResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "[Plan] 플랜 관련 API (V2)")
+public interface PlanApi {
+
+    @Operation(summary = "플랜 전체 목록 조회 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "플랜 목록 조회 성공"),
+            @ApiResponse(
+                    responseCode = "4xx",
+                    description = "유효하지 않은 요청",
+                    content = @Content(schema = @Schema(implementation = FailureResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = FailureResponse.class))
+            )
+    })
+    ResponseEntity<SuccessResponse<PlansAllGetResponse>> getAllPlans();
+}

--- a/smeem-api/src/main/java/com/smeem/api/plan/api/PlanController.java
+++ b/smeem-api/src/main/java/com/smeem/api/plan/api/PlanController.java
@@ -1,0 +1,27 @@
+package com.smeem.api.plan.api;
+
+import com.smeem.api.common.SuccessResponse;
+import com.smeem.api.plan.api.dto.response.PlansAllGetResponse;
+import com.smeem.api.plan.service.PlanService;
+import com.smeem.api.support.ApiResponseGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.smeem.common.code.success.PlanSuccessCode.SUCCESS_GET_ALL_PLAN;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/plans")
+public class PlanController implements PlanApi {
+
+    private final PlanService planService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<SuccessResponse<PlansAllGetResponse>> getAllPlans() {
+        val response = PlansAllGetResponse.of(planService.getAllPlans());
+        return ApiResponseGenerator.success(SUCCESS_GET_ALL_PLAN, response);
+    }
+}

--- a/smeem-api/src/main/java/com/smeem/api/plan/api/dto/response/PlansAllGetResponse.java
+++ b/smeem-api/src/main/java/com/smeem/api/plan/api/dto/response/PlansAllGetResponse.java
@@ -1,0 +1,35 @@
+package com.smeem.api.plan.api.dto.response;
+
+import com.smeem.api.plan.service.dto.response.PlansAllGetServiceResponse;
+import com.smeem.api.plan.service.dto.response.PlansAllGetServiceResponse.PlanServiceResponse;
+import lombok.Builder;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
+public record PlansAllGetResponse(
+        List<PlanResponse> plans
+) {
+
+    public static PlansAllGetResponse of(PlansAllGetServiceResponse response) {
+        return PlansAllGetResponse.builder()
+                .plans(response.plans().stream().map(PlanResponse::of).toList())
+                .build();
+    }
+
+    @Builder(access = PRIVATE)
+    private record PlanResponse(
+            long id,
+            String content
+    ) {
+
+        private static PlanResponse of(PlanServiceResponse response) {
+            return PlanResponse.builder()
+                    .id(response.id())
+                    .content(response.content())
+                    .build();
+        }
+    }
+}

--- a/smeem-api/src/main/java/com/smeem/api/plan/service/PlanService.java
+++ b/smeem-api/src/main/java/com/smeem/api/plan/service/PlanService.java
@@ -1,0 +1,21 @@
+package com.smeem.api.plan.service;
+
+import com.smeem.api.plan.service.dto.response.PlansAllGetServiceResponse;
+import com.smeem.domain.plan.adapter.PlanFinder;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PlanService {
+
+    private final PlanFinder planFinder;
+
+    public PlansAllGetServiceResponse getAllPlans() {
+        val plans = planFinder.findAll();
+        return PlansAllGetServiceResponse.of(plans);
+    }
+}

--- a/smeem-api/src/main/java/com/smeem/api/plan/service/dto/response/PlansAllGetServiceResponse.java
+++ b/smeem-api/src/main/java/com/smeem/api/plan/service/dto/response/PlansAllGetServiceResponse.java
@@ -1,0 +1,34 @@
+package com.smeem.api.plan.service.dto.response;
+
+import com.smeem.domain.plan.model.Plan;
+import lombok.Builder;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
+public record PlansAllGetServiceResponse(
+        List<PlanServiceResponse> plans
+) {
+
+    public static PlansAllGetServiceResponse of(List<Plan> plans) {
+        return PlansAllGetServiceResponse.builder()
+                .plans(plans.stream().map(PlanServiceResponse::of).toList())
+                .build();
+    }
+
+    @Builder(access = PRIVATE)
+    public record PlanServiceResponse(
+            long id,
+            String content
+    ) {
+
+        private static PlanServiceResponse of(Plan plan) {
+            return PlanServiceResponse.builder()
+                    .id(plan.getId())
+                    .content(plan.getContent())
+                    .build();
+        }
+    }
+}

--- a/smeem-api/src/main/java/com/smeem/api/support/ExceptionInterceptor.java
+++ b/smeem-api/src/main/java/com/smeem/api/support/ExceptionInterceptor.java
@@ -5,6 +5,7 @@ import com.smeem.domain.badge.exception.BadgeException;
 import com.smeem.domain.diary.exception.DiaryException;
 import com.smeem.domain.goal.exception.GoalException;
 import com.smeem.domain.member.exception.MemberException;
+import com.smeem.domain.plan.exception.PlanException;
 import com.smeem.domain.topic.exception.TopicException;
 import com.smeem.domain.training.exception.TrainingTimeException;
 import com.smeem.external.discord.DiscordAlarmSender;
@@ -73,6 +74,11 @@ public class ExceptionInterceptor {
 
     @ExceptionHandler(AuthException.class)
     public ResponseEntity<FailureResponse> authException(AuthException exception) {
+        return ApiResponseGenerator.failure(exception.getFailureCode());
+    }
+
+    @ExceptionHandler(PlanException.class)
+    public ResponseEntity<FailureResponse> authException(PlanException exception) {
         return ApiResponseGenerator.failure(exception.getFailureCode());
     }
 

--- a/smeem-common/src/main/java/com/smeem/common/code/failure/PlanFailureCode.java
+++ b/smeem-common/src/main/java/com/smeem/common/code/failure/PlanFailureCode.java
@@ -1,0 +1,21 @@
+package com.smeem.common.code.failure;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@RequiredArgsConstructor
+@Getter
+public enum PlanFailureCode implements FailureCode {
+
+    /**
+     * 404 NOT FOUND
+     */
+    INVALID_PLAN(NOT_FOUND, "유효하지 않은 플랜입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/smeem-common/src/main/java/com/smeem/common/code/success/PlanSuccessCode.java
+++ b/smeem-common/src/main/java/com/smeem/common/code/success/PlanSuccessCode.java
@@ -1,0 +1,21 @@
+package com.smeem.common.code.success;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@RequiredArgsConstructor
+@Getter
+public enum PlanSuccessCode implements SuccessCode {
+
+    /**
+     * 200 Ok
+     */
+    SUCCESS_GET_ALL_PLAN(OK, "플랜 전체 조회 성공"),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/smeem-domain/src/main/java/com/smeem/domain/member/model/Member.java
+++ b/smeem-domain/src/main/java/com/smeem/domain/member/model/Member.java
@@ -143,4 +143,8 @@ public class Member extends BaseTimeEntity {
         val visitCount = Objects.nonNull(this.visitInfo) ? this.visitInfo.getVisitCount() : null;
         return Objects.nonNull(visitCount) ? visitCount : 1;
     }
+
+    public void updatePlan(Plan plan) {
+        this.plan = plan;
+    }
 }

--- a/smeem-domain/src/main/java/com/smeem/domain/plan/adapter/PlanFinder.java
+++ b/smeem-domain/src/main/java/com/smeem/domain/plan/adapter/PlanFinder.java
@@ -1,0 +1,23 @@
+package com.smeem.domain.plan.adapter;
+
+import com.smeem.domain.plan.exception.PlanException;
+import com.smeem.domain.plan.model.Plan;
+import com.smeem.domain.plan.repository.PlanRepository;
+import com.smeem.domain.support.RepositoryAdapter;
+import lombok.RequiredArgsConstructor;
+
+import static com.smeem.common.code.failure.PlanFailureCode.INVALID_PLAN;
+
+@RepositoryAdapter
+@RequiredArgsConstructor
+public class PlanFinder {
+
+    private final PlanRepository planRepository;
+
+    public Plan findById(final long id) {
+        return planRepository.findById(id)
+                .orElseThrow(() -> new PlanException(INVALID_PLAN));
+    }
+}
+
+

--- a/smeem-domain/src/main/java/com/smeem/domain/plan/adapter/PlanFinder.java
+++ b/smeem-domain/src/main/java/com/smeem/domain/plan/adapter/PlanFinder.java
@@ -6,6 +6,8 @@ import com.smeem.domain.plan.repository.PlanRepository;
 import com.smeem.domain.support.RepositoryAdapter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 import static com.smeem.common.code.failure.PlanFailureCode.INVALID_PLAN;
 
 @RepositoryAdapter
@@ -17,6 +19,10 @@ public class PlanFinder {
     public Plan findById(final long id) {
         return planRepository.findById(id)
                 .orElseThrow(() -> new PlanException(INVALID_PLAN));
+    }
+
+    public List<Plan> findAll() {
+        return planRepository.findAll();
     }
 }
 

--- a/smeem-domain/src/main/java/com/smeem/domain/plan/exception/PlanException.java
+++ b/smeem-domain/src/main/java/com/smeem/domain/plan/exception/PlanException.java
@@ -1,0 +1,16 @@
+package com.smeem.domain.plan.exception;
+
+import com.smeem.common.code.failure.FailureCode;
+import com.smeem.common.code.failure.PlanFailureCode;
+import lombok.Getter;
+
+@Getter
+public class PlanException extends RuntimeException {
+
+    private final FailureCode failureCode;
+
+    public PlanException(PlanFailureCode failureCode) {
+        super("[PlanException] : " + failureCode.getMessage());
+        this.failureCode = failureCode;
+    }
+}

--- a/smeem-domain/src/main/java/com/smeem/domain/plan/repository/PlanRepository.java
+++ b/smeem-domain/src/main/java/com/smeem/domain/plan/repository/PlanRepository.java
@@ -1,0 +1,7 @@
+package com.smeem.domain.plan.repository;
+
+import com.smeem.domain.plan.model.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+}


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #261 

## Work Description 💚
- 회원 학습 계획 수정 API에서 Request에 Null 가능한 PlanId 추가했습니다.
- 플랜 데이터를 전체 조회하는 API를 개발했습니다.

<br/>

![image](https://github.com/Team-Smeme/Smeme-server-renewal/assets/55437339/3bce5d58-6d36-4d65-8dd0-f549ad168690)

![image](https://github.com/Team-Smeme/Smeme-server-renewal/assets/55437339/f740cb58-6547-4e2d-b368-9fb62c6f0f71)
