### PR TITLE
[TEST] 일기 저장 관련 테스트 코드 작성

### DIFF
--- a/smeem-api/src/test/java/com/smeem/diary/service/DiaryCommandServiceIntegrationTest.java
+++ b/smeem-api/src/test/java/com/smeem/diary/service/DiaryCommandServiceIntegrationTest.java
@@ -1,0 +1,80 @@
+package com.smeem.diary.service;
+
+import com.smeem.api.diary.service.DiaryCommandService;
+import com.smeem.api.diary.service.dto.request.DiaryCreateServiceRequest;
+import com.smeem.domain.diary.repository.DiaryRepository;
+import com.smeem.domain.member.exception.MemberException;
+import com.smeem.domain.member.model.Member;
+import com.smeem.domain.member.repository.MemberRepository;
+import com.smeem.support.ServiceIntegrationTest;
+import com.smeem.support.fixture.MemberFixture;
+import lombok.val;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static com.smeem.common.code.failure.MemberFailureCode.CANNOT_WRITE_DIARY;
+import static org.assertj.core.api.Assertions.*;
+
+public class DiaryCommandServiceIntegrationTest extends ServiceIntegrationTest {
+
+    @Autowired
+    private DiaryCommandService diaryService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private DiaryRepository diaryRepository;
+
+    private final String MEMBER_EXCEPTION_PREFIX_MESSAGE = "[MemberException] : ";
+
+    @Nested
+    @DisplayName("일기 저장 테스트")
+    class SaveTest {
+
+        private Member member;
+        private final String diaryContent = "test-diary-content";
+
+        @BeforeEach
+        void setUp() {
+            memberRepository.deleteAllInBatch();
+            diaryRepository.deleteAllInBatch();
+            member = memberRepository.save(MemberFixture.member().build());
+        }
+        @Test
+        @Transactional
+        @DisplayName("[성공] 오늘 일기를 작성하지 않은 회원은 일기를 작성할 수 있고, 연속 일기 작성 수가 업데이트된다.")
+        void saveWithMemberNotCreateDiaryToday() {
+            // given
+            val request = new DiaryCreateServiceRequest(member.getId(), diaryContent, null);
+
+            // when
+            val result = diaryService.createDiary(request);
+
+            // then
+            assertThat(member.getDiaryComboCount()).isEqualTo(1);
+
+            val diary = diaryRepository.findFirstByMemberOrderByCreatedAtDesc(member);
+            assertThat(diary).isPresent();
+            assertThat(diary.get().getId()).isEqualTo(result.diaryId());
+            assertThat(diary.get().getCreatedAt().toLocalDate()).isEqualTo(LocalDate.now());
+            assertThat(diary.get().getMember()).isEqualTo(member);
+        }
+
+        @Test
+        @DisplayName("[예외] 오늘 일기를 작성한 회원은 일기를 작성할 수 없다.")
+        void saveWithMemberCreateDiaryToday() {
+            // given
+            val request = new DiaryCreateServiceRequest(member.getId(), diaryContent, null);
+            diaryService.createDiary(request);
+
+            // when & then
+            assertThatThrownBy(() -> diaryService.createDiary(request))
+                    .isInstanceOf(MemberException.class)
+                    .hasMessage(MEMBER_EXCEPTION_PREFIX_MESSAGE + CANNOT_WRITE_DIARY.getMessage());
+        }
+    }
+}

--- a/smeem-api/src/test/java/com/smeem/support/ServiceIntegrationTest.java
+++ b/smeem-api/src/test/java/com/smeem/support/ServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.smeem.support;
 
+import com.smeem.api.SmemeServerRenewalApplication;
 import com.smeem.api.auth.jwt.TokenProvider;
 import com.smeem.api.auth.jwt.TokenValidator;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,7 +10,7 @@ import org.springframework.test.context.TestExecutionListeners;
 
 import static org.springframework.test.context.TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS;
 
-@SpringBootTest
+@SpringBootTest(classes = SmemeServerRenewalApplication.class)
 @TestExecutionListeners(mergeMode = MERGE_WITH_DEFAULTS)
 @ActiveProfiles("test")
 public abstract class ServiceIntegrationTest {

--- a/smeem-api/src/test/java/com/smeem/support/fixture/MemberFixture.java
+++ b/smeem-api/src/test/java/com/smeem/support/fixture/MemberFixture.java
@@ -1,0 +1,32 @@
+package com.smeem.support.fixture;
+
+import com.smeem.domain.member.model.LangType;
+import com.smeem.domain.member.model.Member;
+import com.smeem.domain.member.model.SocialType;
+import lombok.NoArgsConstructor;
+
+import static com.smeem.domain.member.model.LangType.en;
+import static com.smeem.domain.member.model.SocialType.KAKAO;
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public class MemberFixture {
+
+    private Long id;
+    private SocialType social = KAKAO;
+    private String socialId = "test-social-id";
+    private LangType targetLang = en;
+
+    public static MemberFixture member() {
+        return new MemberFixture();
+    }
+
+    public MemberFixture id(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public Member build() {
+        return new Member(id, social, socialId, targetLang);
+    }
+}

--- a/smeem-domain/src/main/java/com/smeem/domain/diary/repository/DiaryRepository.java
+++ b/smeem-domain/src/main/java/com/smeem/domain/diary/repository/DiaryRepository.java
@@ -4,6 +4,9 @@ import com.smeem.domain.diary.model.Diary;
 import com.smeem.domain.member.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     void deleteAllByMember(Member member);
+    Optional<Diary> findFirstByMemberOrderByCreatedAtDesc(Member member);
 }

--- a/smeem-domain/src/main/java/com/smeem/domain/member/model/Member.java
+++ b/smeem-domain/src/main/java/com/smeem/domain/member/model/Member.java
@@ -88,6 +88,15 @@ public class Member extends BaseTimeEntity {
         this.visitInfo = new MemberVisitInfo();
     }
 
+    public Member(Long id, SocialType social, String socialId, LangType targetLang) {
+        this.id = id;
+        this.social = social;
+        this.socialId = socialId;
+        this.targetLang = targetLang;
+        this.diaryComboInfo = new DiaryComboInfo();
+        this.visitInfo = new MemberVisitInfo();
+    }
+
     public void updateUsername(String username) {
         this.username = username;
     }
@@ -163,6 +172,10 @@ public class Member extends BaseTimeEntity {
                 .filter(diary -> isBetweenThisWeek(diary.getCreatedAt().toLocalDate()))
                 .toList()
                 .size();
+    }
+
+    public int getDiaryComboCount() {
+        return this.diaryComboInfo.getDiaryComboCount();
     }
 
     private boolean isBetweenThisWeek(LocalDate date) {


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #287 

## Work Description 💚
- 오늘 일기를 작성하지 않은 회원은 일기를 생성할 수 있고, 일기 연속 작성 수가 업데이트된다.
- 오늘 일기를 작성한 회원은 일기를 작성할 수 없다.

## Comment 💬 
- 테스트 코드 설정 관련 [에러](https://unhosted.tistory.com/77)가 발생하여 대응했습니다.
- 노션에 정리한 테스트 코드 컨벤션 참고하여 테스트 코드를 작성했습니다.
  - MemberFixture를 생성할 때 NotNullable한 칼럼은 기본값을 지정했습니다.
  - Description 항목 내 2가지 기능을 테스트 했습니다.
- 부족한 점 또는 관련 논의할 사항이 있다면 리뷰 추가해주시면 감사하겠습니다!