### PR TITLE
[FIX] 배지 획득까지 남은 횟수 반환 로직 수정

### DIFF
--- a/smeem-api/src/main/java/com/smeem/api/badge/service/BadgeService.java
+++ b/smeem-api/src/main/java/com/smeem/api/badge/service/BadgeService.java
@@ -83,7 +83,7 @@ public class BadgeService {
 
     private BadgeGetServiceResponseV3 convertToBadgeGetServiceResponseV3(Badge badge, final long memberId) {
         val member = memberFinder.findById(memberId);
-        val hasBadge = memberBadgeFinder.isExist(member, badge);
+        val hasBadge = memberBadgeFinder.isExistByMemberAndBadge(member, badge);
         val memberDiaryCount = member.getDiaries().size();
         val remainingNumber = calculateRemainingNumber(badge.getId(), memberDiaryCount);
         return BadgeGetServiceResponseV3.of(badge, hasBadge, remainingNumber);

--- a/smeem-domain/src/main/java/com/smeem/domain/member/adapter/memberbadge/MemberBadgeCounter.java
+++ b/smeem-domain/src/main/java/com/smeem/domain/member/adapter/memberbadge/MemberBadgeCounter.java
@@ -1,6 +1,5 @@
 package com.smeem.domain.member.adapter.memberbadge;
 
-
 import com.smeem.domain.badge.model.Badge;
 import com.smeem.domain.member.repository.MemberBadgeRepository;
 import com.smeem.domain.support.RepositoryAdapter;
@@ -14,9 +13,5 @@ public class MemberBadgeCounter {
 
     public long countByBadge(final Badge badge) {
         return memberBadgeRepository.countByBadge(badge);
-    }
-
-    public long countByBadgeIdAndMemberId(final long badgeId, final long memberId) {
-        return memberBadgeRepository.countByBadgeIdAndMemberId(badgeId, memberId);
     }
 }

--- a/smeem-domain/src/main/java/com/smeem/domain/member/adapter/memberbadge/MemberBadgeFinder.java
+++ b/smeem-domain/src/main/java/com/smeem/domain/member/adapter/memberbadge/MemberBadgeFinder.java
@@ -26,7 +26,7 @@ public class MemberBadgeFinder {
                 .orElseThrow(() -> new MemberException(MemberFailureCode.EMPTY_MEMBER));
     }
 
-    public boolean isExist(Member member, Badge badge) {
+    public boolean isExistByMemberAndBadge(Member member, Badge badge) {
         return memberBadgeRepository.existsByMemberAndBadge(member, badge);
     }
 

--- a/smeem-domain/src/main/java/com/smeem/domain/member/adapter/memberbadge/MemberBadgeFinder.java
+++ b/smeem-domain/src/main/java/com/smeem/domain/member/adapter/memberbadge/MemberBadgeFinder.java
@@ -1,7 +1,9 @@
 package com.smeem.domain.member.adapter.memberbadge;
 
 import com.smeem.common.code.failure.MemberFailureCode;
+import com.smeem.domain.badge.model.Badge;
 import com.smeem.domain.member.exception.MemberException;
+import com.smeem.domain.member.model.Member;
 import com.smeem.domain.member.model.MemberBadge;
 import com.smeem.domain.member.repository.MemberBadgeRepository;
 import com.smeem.domain.support.RepositoryAdapter;
@@ -22,6 +24,10 @@ public class MemberBadgeFinder {
     public MemberBadge findFirstByMemberIdOrderByCreatedAtDesc(final long id) {
         return memberBadgeRepository.findFirstByMemberIdOrderByCreatedAtDesc(id)
                 .orElseThrow(() -> new MemberException(MemberFailureCode.EMPTY_MEMBER));
+    }
+
+    public boolean isExist(Member member, Badge badge) {
+        return memberBadgeRepository.existsByMemberAndBadge(member, badge);
     }
 
 }

--- a/smeem-domain/src/main/java/com/smeem/domain/member/repository/MemberBadgeRepository.java
+++ b/smeem-domain/src/main/java/com/smeem/domain/member/repository/MemberBadgeRepository.java
@@ -1,6 +1,7 @@
 package com.smeem.domain.member.repository;
 
 import com.smeem.domain.badge.model.Badge;
+import com.smeem.domain.member.model.Member;
 import com.smeem.domain.member.model.MemberBadge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,8 +12,6 @@ public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long> 
 
     List<MemberBadge> findAllByMemberId(final long memberId);
     Optional<MemberBadge> findFirstByMemberIdOrderByCreatedAtDesc(final long memberId);
-
     long countByBadge(Badge badge);
-
-    long countByBadgeIdAndMemberId(final long badgeId, final long memberId);
+    boolean existsByMemberAndBadge(Member member, Badge badge);
 }


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #289 

## Work Description 💚
<img width="844" alt="image" src="https://github.com/Team-Smeme/Smeme-server-renewal/assets/55437339/e7959d36-d766-47b3-ac2b-da564f267694">

- 배지 획득까지 남은 횟수를 계산하는 로직을 수정했습니다.
- 일기를 1개 작성한 회원 기준 10개 카운팅 배지 획득까지 9번 남았음 데이터를 반환하는 결과를 이미지를 통해 확인할 수 있습니다.