### PR TITLE
chore: discord logging for coaching survey

### DIFF
--- a/smeem-application/src/main/java/com/smeem/application/domain/survey/DissatisfactionType.java
+++ b/smeem-application/src/main/java/com/smeem/application/domain/survey/DissatisfactionType.java
@@ -1,7 +1,12 @@
 package com.smeem.application.domain.survey;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.smeem.common.exception.ExceptionCode;
+import com.smeem.common.exception.SmeemException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Getter
@@ -14,4 +19,19 @@ public enum DissatisfactionType {
     ;
 
     private final String description;
+
+    @JsonCreator
+    public static DissatisfactionType fromString(String value) {
+        try {
+            return DissatisfactionType.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new SmeemException(ExceptionCode.INVALID_ENUM_TYPE, value);
+        }
+    }
+
+    public static List<DissatisfactionType> fromStringArray(List<String> values) {
+        return values.stream()
+                .map(DissatisfactionType::fromString)
+                .toList();
+    }
 }

--- a/smeem-application/src/main/java/com/smeem/application/domain/survey/SurveyService.java
+++ b/smeem-application/src/main/java/com/smeem/application/domain/survey/SurveyService.java
@@ -44,7 +44,7 @@ public class SurveyService implements SurveyUseCase {
         }
     }
 
-    private void validateDissatisfactionType(boolean isSatisfied, List<DissatisfactionType> dissatisfactionTypes) {
+    private void validateDissatisfactionType(boolean isSatisfied, List<String> dissatisfactionTypes) {
         if (isSatisfied && (dissatisfactionTypes != null && !dissatisfactionTypes.isEmpty())) {
             throw new SmeemException(ExceptionCode.INVALID_FIELD, "불만족을 선택한 경우에만 유형을 선택할 수 있습니다.");
         }

--- a/smeem-application/src/main/java/com/smeem/application/port/input/dto/request/survey/CoachingSurveyRequest.java
+++ b/smeem-application/src/main/java/com/smeem/application/port/input/dto/request/survey/CoachingSurveyRequest.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record CoachingSurveyRequest(
         long diaryId,
         boolean isSatisfied,
-        List<DissatisfactionType> dissatisfactionTypes,
+        List<String> dissatisfactionTypes,
         String reason
 ) {
 
@@ -16,7 +16,7 @@ public record CoachingSurveyRequest(
         return CoachingSurvey.builder()
                 .diaryId(diaryId)
                 .isSatisfied(isSatisfied)
-                .dissatisfactionTypes(dissatisfactionTypes)
+                .dissatisfactionTypes(DissatisfactionType.fromStringArray(dissatisfactionTypes))
                 .reason(reason)
                 .build();
     }

--- a/smeem-common/src/main/java/com/smeem/common/config/DiscordProperties.java
+++ b/smeem-common/src/main/java/com/smeem/common/config/DiscordProperties.java
@@ -14,7 +14,8 @@ public record DiscordProperties(
         public record Url(
            String sign_in,
            String withdraw,
-           String error
+           String error,
+           String survey
         ) {
         }
     }

--- a/smeem-common/src/main/java/com/smeem/common/exception/ExceptionCode.java
+++ b/smeem-common/src/main/java/com/smeem/common/exception/ExceptionCode.java
@@ -12,8 +12,8 @@ public enum ExceptionCode {
     UNAUTHORIZED(401, "유효하지 않은 토큰 "),
     NOT_FOUND(404, "존재하지 않음 "),
     TOO_MANY_REQUESTS(429, "너무 많은 요청"),
-    MISSING_FIELD(400, "필수 값이 누락되었습니다."),
-    INVALID_FIELD(400, "잘못된 필드 값입니다."),
+    INVALID_FIELD(400, "잘못된 필드 값"),
+    INVALID_ENUM_TYPE(400, "유효하지 않은 Enum 값"),
 
     // 5xx
     SERVICE_AVAILABLE(503, "서비스에 접근할 수 없음 "),

--- a/smeem-common/src/main/java/com/smeem/common/logger/LoggerType.java
+++ b/smeem-common/src/main/java/com/smeem/common/logger/LoggerType.java
@@ -9,6 +9,7 @@ public enum LoggerType {
     SIGN_IN("회원가입 알리미"),
     WITHDRAW("회원탈퇴 알리미"),
     ERROR("에러 알리미"),
+    SURVEY("만족도 조사 알리미"),
     ;
 
     private final String name;

--- a/smeem-common/src/main/java/com/smeem/common/logger/LoggingMessage.java
+++ b/smeem-common/src/main/java/com/smeem/common/logger/LoggingMessage.java
@@ -54,6 +54,16 @@ public record LoggingMessage(
                 .build();
     }
 
+    public static LoggingMessage coachingSurvey(boolean isSatisfied, String dissatisfactionTypes, String reason) {
+        return LoggingMessage.builder()
+                .title((isSatisfied ? "# 👍 좋은" : "# 👎 아쉬운") + " 만족도 조사 결과")
+                .content((isSatisfied ? "" : "\n불만족 사유: " + dissatisfactionTypes)
+                        + "\n상세 이유: " + reason)
+                .sendAt(LocalDate.now())
+                .noticeType(LoggerType.SURVEY)
+                .build();
+    }
+
     private static String getRequestUri(WebRequest webRequest) {
         val request = ((ServletWebRequest) webRequest).getRequest();
         val path = request.getMethod() + " " + request.getRequestURL();

--- a/smeem-common/src/main/java/com/smeem/common/logger/discord/DiscordHookLogger.java
+++ b/smeem-common/src/main/java/com/smeem/common/logger/discord/DiscordHookLogger.java
@@ -38,6 +38,7 @@ public class DiscordHookLogger implements HookLogger {
             case SIGN_IN -> discordProperties.webhook().url().sign_in();
             case WITHDRAW -> discordProperties.webhook().url().withdraw();
             case ERROR -> discordProperties.webhook().url().error();
+            case SURVEY -> discordProperties.webhook().url().survey();
         };
     }
 }

--- a/smeem-common/src/main/resources/common-config/application-dev.yml
+++ b/smeem-common/src/main/resources/common-config/application-dev.yml
@@ -4,3 +4,4 @@ discord:
       sign_in: ${DISCORD_WEBHOOK_SIGN_IN_URL}
       withdraw: ${DISCORD_WEBHOOK_WITHDRAW_URL}
       error: ${DISCORD_WEBHOOK_ERROR_URL}
+      survey: ${DISCORD_WEBHOOK_SURVEY_URL}

--- a/smeem-common/src/main/resources/common-config/application-local.yml
+++ b/smeem-common/src/main/resources/common-config/application-local.yml
@@ -4,3 +4,4 @@ discord:
       sign_in: ${DISCORD_WEBHOOK_SIGN_IN_URL}
       withdraw: ${DISCORD_WEBHOOK_WITHDRAW_URL}
       error: ${DISCORD_WEBHOOK_ERROR_URL}
+      survey: ${DISCORD_WEBHOOK_SURVEY_URL}

--- a/smeem-common/src/main/resources/common-config/application-prod.yml
+++ b/smeem-common/src/main/resources/common-config/application-prod.yml
@@ -4,3 +4,4 @@ discord:
       sign_in: ${DISCORD_WEBHOOK_SIGN_IN_URL}
       withdraw: ${DISCORD_WEBHOOK_WITHDRAW_URL}
       error: ${DISCORD_WEBHOOK_ERROR_URL}
+      survey: ${DISCORD_WEBHOOK_SURVEY_URL}


### PR DESCRIPTION
<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related issue 🚀
- closed #367 

## Work Description 💚
- 만족도 조사 결과 전송 시 디스코드에도 전송되도록 연동
- infisical에 웹훅 url 추가 및 yml 파일 수정
- dissatisfaction type 요청 값 중 유효하지 않은 값 들어왔을 때 cors에러가 아닌 exception 발생하도록 dto에 로직 추가

## 참고 화면
<img src="https://github.com/user-attachments/assets/9a8358b0-b621-441a-a5ef-97f1346d8fde" width="450">

